### PR TITLE
mega-repo-tool swarmv2 improvements

### DIFF
--- a/build-in-docker.sh
+++ b/build-in-docker.sh
@@ -29,7 +29,15 @@ WORK_DIR=.stack-work-docker
 stack --no-terminal --system-ghc --work-dir $WORK_DIR update
 stack --no-terminal --system-ghc --work-dir $WORK_DIR build -j2 --pedantic --allow-different-user --only-snapshot
 stack --no-terminal --system-ghc --work-dir $WORK_DIR build -j1 --pedantic --allow-different-user
-cp $(stack --system-ghc --work-dir $WORK_DIR path --local-install-root)/bin/* /app/bin
+
+# Copy binaries to ./build/exe/exe
+# We put binaries in separate directories to speed-up docker image creation
+mkdir -p $ROOTDIR/build
+for fullexe in $(stack --work-dir $WORK_DIR path --local-install-root)/bin/*; do
+    exe=$(basename $fullexe)
+    mkdir -p  $ROOTDIR/build/$exe
+    cp $fullexe $ROOTDIR/build/$exe/$exe
+done
 
 # write current git hash, so we know where we are
 GITHASH=$(git log --pretty=format:'%h' -n 1)

--- a/build-in-linux.sh
+++ b/build-in-linux.sh
@@ -12,23 +12,23 @@ ROOTDIR=$(pwd)
 
 # Check that we have somewhat clean working dir
 if [ ! -z "$(git status --porcelain)" ]; then
-	echo "DIRTY WORKINGDIR"
+    echo "DIRTY WORKINGDIR"
 fi
 
 # Don't trust stack.yaml
 export STACK_YAML=stack-lts-6.yaml
 
 if [ $ROOTDIR = "/app/src" ]; then
-	# Different stack root (on docker volume!)
-	export STACK_ROOT=/stack-root
+    # Different stack root (on docker volume!)
+    export STACK_ROOT=/stack-root
 
-	# We DON't start with clean working dir, it takes ages otherwise.
-	# However we use non-default working dir, so we don't need to wipe local changes
-	# Note: separate checkout is preferred anyway!
-	WORK_DIR=.stack-work-docker
-	# rm -rf $WORK_DIR
+    # We DON't start with clean working dir, it takes ages otherwise.
+    # However we use non-default working dir, so we don't need to wipe local changes
+    # Note: separate checkout is preferred anyway!
+    WORK_DIR=.stack-work-docker
+    # rm -rf $WORK_DIR
 else
-	WORK_DIR=.stack-work
+    WORK_DIR=.stack-work
 fi
 
 # --allow-different-user is needed as we build as root inside docker
@@ -36,8 +36,14 @@ stack --no-terminal --work-dir $WORK_DIR update
 stack --no-terminal --work-dir $WORK_DIR build -j3 --pedantic --allow-different-user --only-snapshot
 stack --no-terminal --work-dir $WORK_DIR build -j3 --pedantic --allow-different-user
 
+# Copy binaries to ./build/exe/exe
+# We put binaries in separate directories to speed-up docker image creation
 mkdir -p $ROOTDIR/build
-cp $(stack --work-dir $WORK_DIR path --local-install-root)/bin/* $ROOTDIR/build
+for fullexe in $(stack --work-dir $WORK_DIR path --local-install-root)/bin/*; do
+    exe=$(basename $fullexe)
+    mkdir -p  $ROOTDIR/build/$exe
+    cp $fullexe $ROOTDIR/build/$exe/$exe
+done
 
 # write current git hash, so we know where we are
 GITHASH=$(git log --pretty=format:'%h' -n 1)

--- a/mega-repo-tool.yaml
+++ b/mega-repo-tool.yaml
@@ -1,28 +1,44 @@
 docker-base-image: futurice/base-images:haskell-lts-6-2
 apps:
+  # key is the name of the app (in the hostname)
+  # docker: the name of docker image created
+  # executable: the name of the executable to put into the image
   avatar:
+    docker: avatar
     executable: avatar-server
-  checklist2:
+  checklist:
+    docker: checklist2
     executable: checklist-app-server
   contacts-api:
+    docker: contacts-api
     executable: contacts-server
   favicon:
+    docker: favicon
     executable: favicon
   hours-api:
+    docker: hours-api
     executable: hours-api-server
   planmill-proxy:
+    docker: planmill-proxy
     executable: planmill-proxy-server
   github-proxy:
+    docker: github-proxy
     executable: github-proxy-server
-  proxy-app:
+  prox:
+    docker: proxy-app
     executable: proxy-app-server
-  reports-app:
+  reports:
+    docker: reports-app
     executable: reports-app-server
   spice-stats:
+    docker: spice-stats
     executable: spice-stats-server
-  theme-app:
+  theme:
+    docker: theme-app
     executable: theme-app-server
   sms-proxy:
+    docker: sms-proxy
     executable: sms-proxy-server
   email-proxy:
+    docker: email-proxy
     executable: email-proxy-server

--- a/mega-repo-tool/src/Futurice/App/MegaRepoTool.hs
+++ b/mega-repo-tool/src/Futurice/App/MegaRepoTool.hs
@@ -17,7 +17,7 @@ textArgument m = fromString <$> O.strArgument m
 
 data Cmd
     = ListSnapshotDependencies 
-    | BuildDocker [ImageName]
+    | BuildDocker [AppName]
     | Action (IO ())
 
 listSnapshotDependenciesOptions :: O.Parser Cmd
@@ -25,7 +25,7 @@ listSnapshotDependenciesOptions = pure ListSnapshotDependencies
 
 buildDockerOptions :: O.Parser Cmd
 buildDockerOptions = BuildDocker
-    <$> many (textArgument $ mconcat [ O.metavar ":component", O.help "Component/image to build" ])
+    <$> some (textArgument $ mconcat [ O.metavar ":component", O.help "Component/image to build" ])
 
 packdepsOptions :: O.Parser Cmd
 packdepsOptions = pure $ Action packdepsScript


### PR DESCRIPTION
Docker images are build quicker:
```
Git hash aka tag for images: 4df27d3
Sending build context to Docker daemon 68.16 MB
```

And more follow-ups are printed:

```
Upload images by:
  docker push futurice/proxy-app:4df27d3
Deploy iamges by:
  futuswarm app:deploy --name prox --image proxy-app --tag 4df27d3
```

cc @mixman @kimmoahokas 