### PR TITLE
added employee department and office

### DIFF
--- a/personio-client/fixtures/employee.json
+++ b/personio-client/fixtures/employee.json
@@ -109,7 +109,7 @@
         "type": "Department",
         "attributes": {
           "id": 2,
-          "name": "Finland"
+          "name": "Some Tribe"
         }
       }
     },

--- a/personio-client/tests/Tests.hs
+++ b/personio-client/tests/Tests.hs
@@ -50,6 +50,8 @@ examples = testGroup "HUnit"
         "teemu.teekkari@example.com" @=? e ^. employeeEmail
         "+123 5678910" @=? e ^. employeePhone
         Just (EmployeeId 1337) @=? e ^. employeeSupervisorId
+        "Some Tribe" @=? e ^. employeeDepartment
+        "Helsinki" @=? e ^. employeeOffice
     ]
   where
     contentsM = decodeStrict $(makeRelativeToProject "fixtures/employee.json" >>= embedFile)


### PR DESCRIPTION
Added Employee's office name and department name. Name fields were used since personio-api didn't seem to have support for getting either office or department by their id. If required, names can easily be replaced with ids.