### PR TITLE
filter swagger logs on client-side

### DIFF
--- a/proxy-app/package.yaml
+++ b/proxy-app/package.yaml
@@ -37,6 +37,8 @@ library:
     - planmill-client
     - postgresql-simple
     - reflection
+    - regex-applicative
+    - regex-applicative-text
     - reports-app
     - resource-pool
     - semigroups

--- a/proxy-app/proxy-app.cabal
+++ b/proxy-app/proxy-app.cabal
@@ -50,6 +50,8 @@ library
     , planmill-client
     , postgresql-simple
     , reflection
+    , regex-applicative
+    , regex-applicative-text
     , reports-app
     , resource-pool
     , semigroups


### PR DESCRIPTION
Cleaning proxy-app's log from swagger-entries. This could also be done altering "acceslog"-table (in /proxy-mgmt-app/schema.psql) and adding a condition to column "endpoint" to filter swagger-entries.