### PR TITLE
Proxy app encpass

### DIFF
--- a/proxy-mgmt-app/schema.psql
+++ b/proxy-mgmt-app/schema.psql
@@ -14,16 +14,13 @@ CREATE TABLE proxyapp.accesslog (
   endpoint TEXT NOT NULL
 );
 
-CREATE FUNCTION pass_crypt() RETURNS trigger AS $pass_crypt$
+CREATE FUNCTION proxyapp.pass_crypt() RETURNS trigger AS $pass_crypt$
   BEGIN
-    -- If given passtext is non-empty, encrypt it
-    IF NEW.passtext IS NOT NULL AND NEW.passtext NOT LIKE '' THEN
-      NEW.passtext = crypt(NEW.passtext, gen_salt('md5'));
-    END IF;
+    NEW.passtext = crypt(NEW.passtext, gen_salt('bf'));
 
     RETURN NEW;
   END;
  $pass_crypt$ LANGUAGE plpgsql;
 
 CREATE TRIGGER pass_crypt BEFORE INSERT OR UPDATE ON proxyapp.credentials
-  FOR EACH ROW EXECUTE PROCEDURE pass_crypt();
+  FOR EACH ROW EXECUTE PROCEDURE proxyapp.pass_crypt();

--- a/proxy-mgmt-app/schema.psql
+++ b/proxy-mgmt-app/schema.psql
@@ -12,3 +12,18 @@ CREATE TABLE proxyapp.accesslog (
   updated TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
   endpoint TEXT NOT NULL
 );
+
+CREATE EXTENSION pgcrypto;
+
+CREATE FUNCTION pass_crypt() RETURNS trigger AS $pass_crypt$
+  BEGIN-- If given passtext is non-empty, encrypt it
+    IF NEW.passtext IS NOT NULL AND NEW.passtext NOT LIKE '' THEN
+      NEW.passtext = crypt(NEW.passtext, gen_salt('md5'));
+    END IF;
+
+    RETURN NEW;
+  END;
+ $pass_crypt$ LANGUAGE plpgsql;
+
+CREATE TRIGGER pass_crypt BEFORE INSERT OR UPDATE ON proxyapp.credentials
+  FOR EACH ROW EXECUTE PROCEDURE pass_crypt();

--- a/proxy-mgmt-app/schema.psql
+++ b/proxy-mgmt-app/schema.psql
@@ -1,4 +1,5 @@
 -- CREATE SCHEMA proxyapp;
+CREATE EXTENSION pgcrypto;
 
 CREATE TABLE proxyapp.credentials (
   username TEXT PRIMARY KEY,
@@ -12,8 +13,6 @@ CREATE TABLE proxyapp.accesslog (
   updated TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
   endpoint TEXT NOT NULL
 );
-
-CREATE EXTENSION pgcrypto;
 
 CREATE FUNCTION pass_crypt() RETURNS trigger AS $pass_crypt$
   BEGIN

--- a/proxy-mgmt-app/schema.psql
+++ b/proxy-mgmt-app/schema.psql
@@ -16,7 +16,8 @@ CREATE TABLE proxyapp.accesslog (
 CREATE EXTENSION pgcrypto;
 
 CREATE FUNCTION pass_crypt() RETURNS trigger AS $pass_crypt$
-  BEGIN-- If given passtext is non-empty, encrypt it
+  BEGIN
+    -- If given passtext is non-empty, encrypt it
     IF NEW.passtext IS NOT NULL AND NEW.passtext NOT LIKE '' THEN
       NEW.passtext = crypt(NEW.passtext, gen_salt('md5'));
     END IF;


### PR DESCRIPTION
Simplest option as long credentials are added via database.

Instead of

username | passtext
--- | ---
masa | mainio

Will be for example

username | passtext
--- | ---
masa | $1$ayXG/ESL$aT/o0VV5fIi8Ow7G8sxo64

- Will require rebase after ACL has been added.