### PR TITLE
Added employment type, validated external contract end date

### DIFF
--- a/personio-client/fixtures/employee-m-endd.json
+++ b/personio-client/fixtures/employee-m-endd.json
@@ -1,0 +1,285 @@
+{
+    "type": "Employee",
+    "attributes": {
+        "id": {
+            "label": "id",
+            "value": 42
+        },
+        "first_name": {
+            "label": "First name",
+            "value": "Teemu"
+        },
+        "last_name": {
+            "label": "Last name",
+            "value": "Teekkari"
+        },
+        "email": {
+            "label": "Email",
+            "value": "teemu.teekkari@example.com"
+        },
+        "gender": {
+            "label": "Gender",
+            "value": "female"
+        },
+        "status": {
+            "label": "Status",
+            "value": "active"
+        },
+        "position": {
+            "label": "Position",
+            "value": "Tester"
+        },
+        "supervisor": {
+            "label": "Supervisor",
+            "value": {
+                "type": "Employee",
+                "attributes": {
+                    "id": {
+                        "label": "id",
+                        "value": 1337
+                    },
+                    "first_name": {
+                        "label": "First name",
+                        "value": "Esko"
+                    },
+                    "last_name": {
+                        "label": "Last name",
+                        "value": "Karvinen"
+                    },
+                    "email": {
+                        "label": "Email",
+                        "value": "esko.karvinen@example.com"
+                    }
+                }
+            }
+        },
+        "employment_type": {
+            "label": "Employment type",
+            "value": "external"
+        },
+        "weekly_working_hours": {
+            "label": "Weekly hours",
+            "value": "37.5"
+        },
+        "hire_date": {
+            "label": "Hire date",
+            "value": "2017-05-29T00:00:00+01:00"
+        },
+        "contract_end_date": {
+            "label": "Contract ends",
+            "value": null
+        },
+        "termination_date": {
+            "label": "Termination date",
+            "value": null
+        },
+        "termination_type": {
+            "label": "Termination type",
+            "value": ""
+        },
+        "termination_reason": {
+            "label": "Termination reason",
+            "value": ""
+        },
+        "probation_period_end": {
+            "label": "Probation period end",
+            "value": null
+        },
+        "created_at": {
+            "label": "created_at",
+            "value": "2017-05-24T16:01:45+02:00"
+        },
+        "subcompany": {
+            "label": "subcompany",
+            "value": []
+        },
+        "office": {
+            "label": "Office",
+            "value": {
+                "type": "Office",
+                "attributes": {
+                    "id": 1,
+                    "name": "Helsinki"
+                }
+            }
+        },
+        "department": {
+            "label": "Department",
+            "value": {
+                "type": "Department",
+                "attributes": {
+                    "id": 2,
+                    "name": "A Tribe"
+                }
+            }
+        },
+        "cost_centers": {
+            "label": "Cost center",
+            "value": []
+        },
+        "fix_salary": {
+            "label": "Fix salary",
+            "value": 0
+        },
+        "hourly_salary": {
+            "label": "Hourly salary",
+            "value": 0
+        },
+        "vacation_day_balance": {
+            "label": "Vacation day balance",
+            "value": 0
+        },
+        "dynamic_27163": {
+            "label": "Work phone",
+            "value": "+123 5678910"
+        },
+        "dynamic_65806": {
+            "label": "Studies",
+            "value": ""
+        },
+        "dynamic_66136": {
+            "label": "HR number",
+            "value": 0
+        },
+        "dynamic_72952": {
+            "label": "Base salary",
+            "value": ""
+        },
+        "dynamic_72910": {
+            "label": "Primary role",
+            "value": "Developer (Primary)"
+        },
+        "dynamic_65812": {
+            "label": "(FI) Social Security Number",
+            "value": ""
+        },
+        "dynamic_66529": {
+            "label": "Degree",
+            "value": ""
+        },
+        "dynamic_72955": {
+            "label": "Variable salary",
+            "value": ""
+        },
+        "dynamic_27167": {
+            "label": "LinkedIn",
+            "value": ""
+        },
+        "dynamic_65821": {
+            "label": "(DE) HR Number",
+            "value": ""
+        },
+        "dynamic_66592": {
+            "label": "Study points",
+            "value": ""
+        },
+        "dynamic_72958": {
+            "label": "Company car",
+            "value": ""
+        },
+        "dynamic_72961": {
+            "label": "Accommodation benefit",
+            "value": ""
+        },
+        "dynamic_72928": {
+            "label": "(DE) ID number",
+            "value": ""
+        },
+        "dynamic_72913": {
+            "label": "Github",
+            "value": "https://github.com/gitMastur"
+        },
+        "dynamic_66595": {
+            "label": "Degree stage",
+            "value": ""
+        },
+        "dynamic_72931": {
+            "label": "(DE) Social security number (SV)",
+            "value": ""
+        },
+        "dynamic_72964": {
+            "label": "Parking lot",
+            "value": ""
+        },
+        "dynamic_66598": {
+            "label": "Year of graduation",
+            "value": ""
+        },
+        "dynamic_72982": {
+            "label": "Login name",
+            "value": "vsch"
+        },
+        "dynamic_27165": {
+            "label": "Birthday",
+            "value": "1849-01-01T00:00:00+01:00"
+        },
+        "dynamic_72967": {
+            "label": "Additional benefits",
+            "value": ""
+        },
+        "dynamic_72970": {
+            "label": "Expat bonus",
+            "value": ""
+        },
+        "dynamic_66601": {
+            "label": "Nationality",
+            "value": "Finnish"
+        },
+        "dynamic_72973": {
+            "label": "FutuBonus",
+            "value": ""
+        },
+        "dynamic_66604": {
+            "label": "Work permit",
+            "value": ""
+        },
+        "dynamic_72937": {
+            "label": "Work permit ends on",
+            "value": ""
+        },
+        "dynamic_72976": {
+            "label": "IBAN",
+            "value": "GB82 WEST 1234 5698 7654 32"
+        },
+        "dynamic_72919": {
+            "label": "Work time in %",
+            "value": ""
+        },
+        "dynamic_72979": {
+            "label": "BIC",
+            "value": ""
+        },
+        "dynamic_72922": {
+            "label": "Work time in hours",
+            "value": ""
+        },
+        "dynamic_72925": {
+            "label": "End of trial period",
+            "value": ""
+        },
+        "dynamic_72940": {
+            "label": "Career path level",
+            "value": ""
+        },
+        "dynamic_72946": {
+            "label": "Local / Expat",
+            "value": "local"
+        },
+        "dynamic_72949": {
+            "label": "End of expat assignment",
+            "value": ""
+        },
+        "dynamic_72943": {
+            "label": "Home tribe",
+            "value": "SomeTribe"
+        },
+        "dynamic_72916": {
+            "label": "Home address",
+            "value": "Otakaari 1, Espoo"
+        },
+        "dynamic_72934": {
+            "label": "Health insurance",
+            "value": "AOK Nordost in Berlin"
+        }
+    }
+}

--- a/personio-client/fixtures/employee-m-etype.json
+++ b/personio-client/fixtures/employee-m-etype.json
@@ -1,0 +1,285 @@
+{
+    "type": "Employee",
+    "attributes": {
+        "id": {
+            "label": "id",
+            "value": 42
+        },
+        "first_name": {
+            "label": "First name",
+            "value": "Teemu"
+        },
+        "last_name": {
+            "label": "Last name",
+            "value": "Teekkari"
+        },
+        "email": {
+            "label": "Email",
+            "value": "teemu.teekkari@example.com"
+        },
+        "gender": {
+            "label": "Gender",
+            "value": "female"
+        },
+        "status": {
+            "label": "Status",
+            "value": "active"
+        },
+        "position": {
+            "label": "Position",
+            "value": "Tester"
+        },
+        "supervisor": {
+            "label": "Supervisor",
+            "value": {
+                "type": "Employee",
+                "attributes": {
+                    "id": {
+                        "label": "id",
+                        "value": 1337
+                    },
+                    "first_name": {
+                        "label": "First name",
+                        "value": "Esko"
+                    },
+                    "last_name": {
+                        "label": "Last name",
+                        "value": "Karvinen"
+                    },
+                    "email": {
+                        "label": "Email",
+                        "value": "esko.karvinen@example.com"
+                    }
+                }
+            }
+        },
+        "employment_type": {
+            "label": "Employment type",
+            "value": ""
+        },
+        "weekly_working_hours": {
+            "label": "Weekly hours",
+            "value": "37.5"
+        },
+        "hire_date": {
+            "label": "Hire date",
+            "value": "2017-05-29T00:00:00+01:00"
+        },
+        "contract_end_date": {
+            "label": "Contract ends",
+            "value": null
+        },
+        "termination_date": {
+            "label": "Termination date",
+            "value": null
+        },
+        "termination_type": {
+            "label": "Termination type",
+            "value": ""
+        },
+        "termination_reason": {
+            "label": "Termination reason",
+            "value": ""
+        },
+        "probation_period_end": {
+            "label": "Probation period end",
+            "value": null
+        },
+        "created_at": {
+            "label": "created_at",
+            "value": "2017-05-24T16:01:45+02:00"
+        },
+        "subcompany": {
+            "label": "subcompany",
+            "value": []
+        },
+        "office": {
+            "label": "Office",
+            "value": {
+                "type": "Office",
+                "attributes": {
+                    "id": 1,
+                    "name": "Helsinki"
+                }
+            }
+        },
+        "department": {
+            "label": "Department",
+            "value": {
+                "type": "Department",
+                "attributes": {
+                    "id": 2,
+                    "name": "A Tribe"
+                }
+            }
+        },
+        "cost_centers": {
+            "label": "Cost center",
+            "value": []
+        },
+        "fix_salary": {
+            "label": "Fix salary",
+            "value": 0
+        },
+        "hourly_salary": {
+            "label": "Hourly salary",
+            "value": 0
+        },
+        "vacation_day_balance": {
+            "label": "Vacation day balance",
+            "value": 0
+        },
+        "dynamic_27163": {
+            "label": "Work phone",
+            "value": "+123 5678910"
+        },
+        "dynamic_65806": {
+            "label": "Studies",
+            "value": ""
+        },
+        "dynamic_66136": {
+            "label": "HR number",
+            "value": 0
+        },
+        "dynamic_72952": {
+            "label": "Base salary",
+            "value": ""
+        },
+        "dynamic_72910": {
+            "label": "Primary role",
+            "value": "Developer (Primary)"
+        },
+        "dynamic_65812": {
+            "label": "(FI) Social Security Number",
+            "value": ""
+        },
+        "dynamic_66529": {
+            "label": "Degree",
+            "value": ""
+        },
+        "dynamic_72955": {
+            "label": "Variable salary",
+            "value": ""
+        },
+        "dynamic_27167": {
+            "label": "LinkedIn",
+            "value": ""
+        },
+        "dynamic_65821": {
+            "label": "(DE) HR Number",
+            "value": ""
+        },
+        "dynamic_66592": {
+            "label": "Study points",
+            "value": ""
+        },
+        "dynamic_72958": {
+            "label": "Company car",
+            "value": ""
+        },
+        "dynamic_72961": {
+            "label": "Accommodation benefit",
+            "value": ""
+        },
+        "dynamic_72928": {
+            "label": "(DE) ID number",
+            "value": ""
+        },
+        "dynamic_72913": {
+            "label": "Github",
+            "value": "https://github.com/gitMastur"
+        },
+        "dynamic_66595": {
+            "label": "Degree stage",
+            "value": ""
+        },
+        "dynamic_72931": {
+            "label": "(DE) Social security number (SV)",
+            "value": ""
+        },
+        "dynamic_72964": {
+            "label": "Parking lot",
+            "value": ""
+        },
+        "dynamic_66598": {
+            "label": "Year of graduation",
+            "value": ""
+        },
+        "dynamic_72982": {
+            "label": "Login name",
+            "value": "vsch"
+        },
+        "dynamic_27165": {
+            "label": "Birthday",
+            "value": "1849-01-01T00:00:00+01:00"
+        },
+        "dynamic_72967": {
+            "label": "Additional benefits",
+            "value": ""
+        },
+        "dynamic_72970": {
+            "label": "Expat bonus",
+            "value": ""
+        },
+        "dynamic_66601": {
+            "label": "Nationality",
+            "value": "Finnish"
+        },
+        "dynamic_72973": {
+            "label": "FutuBonus",
+            "value": ""
+        },
+        "dynamic_66604": {
+            "label": "Work permit",
+            "value": ""
+        },
+        "dynamic_72937": {
+            "label": "Work permit ends on",
+            "value": ""
+        },
+        "dynamic_72976": {
+            "label": "IBAN",
+            "value": "GB82 WEST 1234 5698 7654 32"
+        },
+        "dynamic_72919": {
+            "label": "Work time in %",
+            "value": ""
+        },
+        "dynamic_72979": {
+            "label": "BIC",
+            "value": ""
+        },
+        "dynamic_72922": {
+            "label": "Work time in hours",
+            "value": ""
+        },
+        "dynamic_72925": {
+            "label": "End of trial period",
+            "value": ""
+        },
+        "dynamic_72940": {
+            "label": "Career path level",
+            "value": ""
+        },
+        "dynamic_72946": {
+            "label": "Local / Expat",
+            "value": "local"
+        },
+        "dynamic_72949": {
+            "label": "End of expat assignment",
+            "value": ""
+        },
+        "dynamic_72943": {
+            "label": "Home tribe",
+            "value": "SomeTribe"
+        },
+        "dynamic_72916": {
+            "label": "Home address",
+            "value": "Otakaari 1, Espoo"
+        },
+        "dynamic_72934": {
+            "label": "Health insurance",
+            "value": "AOK Nordost in Berlin"
+        }
+    }
+}

--- a/personio-client/personio-client.cabal
+++ b/personio-client/personio-client.cabal
@@ -53,6 +53,7 @@ library
       Personio.Eval
       Personio.Request
       Personio.Types
+      Personio.Types.EmployeeEmploymentType
       Personio.Types.EmployeeStatus
   default-language: Haskell2010
 

--- a/personio-client/src/Personio/Types.hs
+++ b/personio-client/src/Personio/Types.hs
@@ -28,7 +28,9 @@ import Futurice.Prelude
 import Prelude ()
 import Text.Regex.Applicative.Text (RE', anySym, match, psym, string)
 
-import Personio.Types.EmployeeStatus (Status (..))
+import Personio.Types.EmployeeEmploymentType
+       (EmploymentType (..), employmentTypeFromText)
+import Personio.Types.EmployeeStatus         (Status (..))
 
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text           as T
@@ -79,22 +81,23 @@ _EmployeeId = prism' toUrlPiece (either (const Nothing) Just . parseUrlPiece)
 
 -- | Employee structure. Doesn't contain sensitive information.
 data Employee = Employee
-    { _employeeId           :: !EmployeeId
-    , _employeeFirst        :: !Text
-    , _employeeLast         :: !Text
-    , _employeeHireDate     :: !(Maybe Day)
-    , _employeeEndDate      :: !(Maybe Day)
-    , _employeeRole         :: !Text
-    , _employeeEmail        :: !Text
-    , _employeePhone        :: !Text
-    , _employeeSupervisorId :: !(Maybe EmployeeId)
-    , _employeeLogin        :: !(Maybe Text) -- TODO 4 or 5 lowercase letters `isLower` not good,
-    , _employeeTribe        :: !(Maybe Text)
-    , _employeeOffice       :: !(Maybe Text)
-    , _employeeCostCenter   :: !(Maybe Text) -- exactly 1
-    , _employeeGithub       :: !(Maybe Text)
-    , _employeeStatus       :: !Status
-    , _employeeHRNumber     :: !(Maybe Int)
+    { _employeeId             :: !EmployeeId
+    , _employeeFirst          :: !Text
+    , _employeeLast           :: !Text
+    , _employeeHireDate       :: !(Maybe Day)
+    , _employeeEndDate        :: !(Maybe Day)
+    , _employeeRole           :: !Text
+    , _employeeEmail          :: !Text
+    , _employeePhone          :: !Text
+    , _employeeSupervisorId   :: !(Maybe EmployeeId)
+    , _employeeLogin          :: !(Maybe Text) -- TODO 4 or 5 lowercase letters `isLower` not good,
+    , _employeeTribe          :: !(Maybe Text)
+    , _employeeOffice         :: !(Maybe Text)
+    , _employeeCostCenter     :: !(Maybe Text) -- exactly 1
+    , _employeeGithub         :: !(Maybe Text)
+    , _employeeStatus         :: !Status
+    , _employeeHRNumber       :: !(Maybe Int)
+    , _employeeEmploymentType :: !EmploymentType
     -- use this when debugging
     -- , employeeRest     :: !(HashMap Text Value)
     }
@@ -170,6 +173,7 @@ parsePersonioEmployee = withObjectDump "Personio.Employee" $ \obj -> do
         <*> fmap getGithubUsername (parseDynamicAttribute obj "Github")
         <*> parseAttribute obj "status"
         <*> parseDynamicAttribute obj "HR number"
+        <*> parseAttribute obj "employment_type"
         -- <*> pure obj -- for employeeRest field
 
 -- | Personio attribute, i.e. labelled value.
@@ -397,6 +401,8 @@ data ValidationMessage
     | PhoneMissing
     | IbanInvalid
     | LoginInvalid Text
+    | EmploymentTypeMissing
+    | ExternalEndDateMissing
   deriving (Eq, Ord, Show, Typeable, Generic)
 
 
@@ -452,7 +458,9 @@ validatePersonioEmployee = withObjectDump "Personio.Employee" $ \obj -> do
         , costCenterValidate
         , ibanValidate
         , loginValidate
+        , extEndDateMissing
         , attributeMissing "email" EmailMissing
+        , attributeMissing "employment_type" EmploymentTypeMissing
         , attributeObjectMissing "department" TribeMissing
         , attributeObjectMissing "office" OfficeMissing
         , dynamicAttributeMissing "Work phone" PhoneMissing
@@ -480,6 +488,7 @@ validatePersonioEmployee = withObjectDump "Personio.Employee" $ \obj -> do
         attributeMissing attrName errMsg = do
             attribute <- lift (parseAttribute obj attrName)
             case attribute of
+                Null     -> tell [errMsg]
                 Array _  -> tell [errMsg]
                 String a -> checkAttributeName a errMsg
                 a        -> lift (typeMismatch (show attrName) a)
@@ -528,6 +537,23 @@ validatePersonioEmployee = withObjectDump "Personio.Employee" $ \obj -> do
             case match loginRegexp login of
                 Nothing -> tell [LoginInvalid login]
                 Just _  -> pure ()
+
+        extEndDateMissing :: WriterT [ValidationMessage] Parser()
+        extEndDateMissing = do
+            eType <- lift (parseAttribute obj "employment_type")
+            case employmentTypeFromText eType of
+                Just External -> checkEndDate
+                _             -> pure ()
+          where
+            checkEndDate = do
+              eDate <- lift (parseAttribute obj "contract_end_date")
+              case eDate of
+                  Null     -> tell [ExternalEndDateMissing]
+                  String d -> checkAttributeName d ExternalEndDateMissing
+                  _        -> pure ()
+
+
+
 
 -- | Validate IBAN.
 --

--- a/personio-client/src/Personio/Types.hs
+++ b/personio-client/src/Personio/Types.hs
@@ -552,9 +552,6 @@ validatePersonioEmployee = withObjectDump "Personio.Employee" $ \obj -> do
                   String d -> checkAttributeName d ExternalEndDateMissing
                   _        -> pure ()
 
-
-
-
 -- | Validate IBAN.
 --
 -- See <https://en.wikipedia.org/wiki/International_Bank_Account_Number#Validating_the_IBAN>

--- a/personio-client/src/Personio/Types/EmployeeEmploymentType.hs
+++ b/personio-client/src/Personio/Types/EmployeeEmploymentType.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeFamilies          #-}
+module Personio.Types.EmployeeEmploymentType
+    (EmploymentType (..), employmentTypeFromText
+    ) where
+
+import Data.Aeson.Compat (Value (String), withText)
+import Data.Swagger (NamedSchema (..))
+import Futurice.Generics
+import Futurice.Prelude
+
+import qualified Data.Map as Map
+import qualified Data.Text as T
+
+data EmploymentType
+    = Internal
+    | External
+    deriving (Eq, Ord, Show, Read, Typeable, Enum, Bounded, Generic)
+
+makePrisms ''EmploymentType
+deriveGeneric ''EmploymentType
+
+instance NFData EmploymentType
+
+instance Arbitrary EmploymentType where
+    arbitrary = sopArbitrary
+    shrink    = sopShrink
+
+employmentTypeToText :: EmploymentType -> Text
+employmentTypeToText Internal = "internal"
+employmentTypeToText External = "external"
+
+instance ToSchema EmploymentType where
+    declareNamedSchema _ = pure $ NamedSchema (Just "Employment type") mempty
+
+employmentTypeFromText :: Text -> Maybe EmploymentType
+employmentTypeFromText t = Map.lookup (T.toLower t) m
+  where
+    m = Map.fromList $
+        map (\x -> (T.toLower $ employmentTypeToText x, x))
+        [minBound .. maxBound]
+
+_EmploymentType :: Prism' Text EmploymentType
+_EmploymentType = prism' employmentTypeToText employmentTypeFromText
+
+instance ToJSON EmploymentType where
+    toJSON = String . employmentTypeToText
+
+instance FromJSON EmploymentType where
+    parseJSON = withText "Employment type" $ \t ->
+        maybe (fail $ "invalid Employment type " <> t ^. unpacked) pure
+        $ t ^? _EmploymentType

--- a/personio-client/tests/Tests.hs
+++ b/personio-client/tests/Tests.hs
@@ -11,6 +11,7 @@ import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
 
 import Personio
+import Personio.Types.EmployeeEmploymentType
 
 main :: IO ()
 main = defaultMain $ testGroup "tests"
@@ -56,7 +57,7 @@ examples = testGroup "HUnit"
         Just "gitMastur" @=? e ^. employeeGithub
         Active @=? e ^. employeeStatus
         Just 0 @=? e ^. employeeHRNumber
-
+        Internal @=? e ^. employeeEmploymentType
     , validations
     ]
   where
@@ -104,6 +105,14 @@ validations = testGroup "Validations"
         "login name"
         $(makeRelativeToProject "fixtures/employee-i-login.json" >>= embedFile)
         $ LoginInvalid "erAt"
+    , testValidation
+        "employment_type"
+        $(makeRelativeToProject "fixtures/employee-m-etype.json" >>= embedFile)
+        EmploymentTypeMissing
+    , testValidation
+        "external contract_end_date"
+        $(makeRelativeToProject "fixtures/employee-m-endd.json" >>= embedFile)
+        ExternalEndDateMissing
     ]
   where
     testValidation name source warning = testCase name $ do


### PR DESCRIPTION
`EmploymentType` was made in similar fashion as `Status`. 
Contract end date should now be present if `EmploymentType` is `External`