### PR TITLE
encodeUtf8 now imported from Prelude

### DIFF
--- a/avatar-app/src/Futurice/App/Avatar.hs
+++ b/avatar-app/src/Futurice/App/Avatar.hs
@@ -17,7 +17,6 @@ import System.IO           (hPutStrLn, stderr)
 
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text            as T
-import qualified Data.Text.Encoding   as TE
 
 -- Avatar modules
 import Futurice.App.Avatar.API
@@ -62,7 +61,7 @@ mkAvatar (logger, cache, mgr) (Just url) msize grey = mk $ do
     f err = ServantErr
         500
         "Avatar conversion error"
-        (LBS.fromStrict . TE.encodeUtf8 . T.pack $ err)
+        (LBS.fromStrict . encodeUtf8 . T.pack $ err)
         []
 
 server :: Ctx -> Server AvatarAPI

--- a/checklist-app/src/Futurice/App/Checklist/Types/TaskAppliance.hs
+++ b/checklist-app/src/Futurice/App/Checklist/Types/TaskAppliance.hs
@@ -19,7 +19,6 @@ import Futurice.Lucid.Foundation (HtmlT, ToHtml (..), class_, em_, span_)
 import Text.Trifecta
 
 import qualified Data.Text                    as T
-import qualified Data.Text.Encoding           as TE
 import qualified Text.PrettyPrint.ANSI.Leijen as PP
 
 import Futurice.App.Checklist.Types.ContractType
@@ -118,7 +117,7 @@ parseTaskAppliance = p . T.toLower . T.strip
     p :: Text -> Either String TaskAppliance
     p ""    = Right TAAll
     p "all" = Right TAAll
-    p t     = case parseByteString taP mempty (TE.encodeUtf8 t) of
+    p t     = case parseByteString taP mempty (encodeUtf8 t) of
         Success q -> Right q
         Failure e -> Left $ PP.displayS (PP.renderCompact  $ _errDoc e) ""
 

--- a/fum-client/src/FUM/Request.hs
+++ b/fum-client/src/FUM/Request.hs
@@ -17,7 +17,6 @@ import Prelude ()
 import Control.Monad.Http.Class (MonadHttp, httpLbs)
 import Data.Aeson.Compat        (FromJSON (..), decode, withObject, (.:))
 
-import qualified Data.Text.Encoding  as TE (encodeUtf8)
 import qualified Data.Vector         as V (empty)
 import qualified Network.HTTP.Client as H
                  (Request (..), parseUrlThrow, responseBody)
@@ -63,7 +62,7 @@ mkReq url = do
     AuthToken token <- view authToken
     BaseUrl base <- view baseUrl
     baseReq <- H.parseUrlThrow $ base <> url
-    let authHeader = ("Authorization", TE.encodeUtf8 $ "Token " <> token)
+    let authHeader = ("Authorization", encodeUtf8 $ "Token " <> token)
     return $ baseReq { H.requestHeaders = authHeader : H.requestHeaders baseReq }
 
 getMulti

--- a/futurice-reports/src/Futurice/Report/Columns.hs
+++ b/futurice-reports/src/Futurice/Report/Columns.hs
@@ -37,6 +37,7 @@ import Data.Aeson                (encode, pairs, (.=))
 import Data.Aeson.Encoding       (encodingToLazyByteString, list, pair)
 import Data.Constraint           (Constraint)
 import Data.Swagger              (NamedSchema (..))
+import Data.Text.Encoding        (decodeUtf8)
 import Futurice.Constraint.Unit1 (Unit1)
 import Futurice.Generics
 import Futurice.IsMaybe
@@ -51,7 +52,6 @@ import Servant.CSV.Cassava       (CSV', EncodeOpts (..))
 
 import qualified Data.Csv           as Csv
 import qualified Data.Set           as Set
-import qualified Data.Text.Encoding as TE
 import qualified Data.Tuple.Strict  as S
 import qualified Generics.SOP       as SOP
 import qualified PlanMill           as PM
@@ -163,7 +163,7 @@ columnControl (ColumnData colname xs) = largemed_ 6 $ div_ [ class_ "futu-report
         "Filter values"
         select_ [ class_ "futu-report-filter", multiple_ "multiple" ] $
             for_ xs' $ \x->
-                option_ [ value_ $ TE.decodeUtf8 $ encode x ^. strict ] $
+                option_ [ value_ $ decodeUtf8 $ encode x ^. strict ] $
                     reportValueHtml x
   where
     colType    = reportValueType (Proxy :: Proxy a)

--- a/futurice-reports/src/Futurice/Report/Columns.hs
+++ b/futurice-reports/src/Futurice/Report/Columns.hs
@@ -37,7 +37,6 @@ import Data.Aeson                (encode, pairs, (.=))
 import Data.Aeson.Encoding       (encodingToLazyByteString, list, pair)
 import Data.Constraint           (Constraint)
 import Data.Swagger              (NamedSchema (..))
-import Data.Text.Encoding        (decodeUtf8)
 import Futurice.Constraint.Unit1 (Unit1)
 import Futurice.Generics
 import Futurice.IsMaybe
@@ -163,7 +162,7 @@ columnControl (ColumnData colname xs) = largemed_ 6 $ div_ [ class_ "futu-report
         "Filter values"
         select_ [ class_ "futu-report-filter", multiple_ "multiple" ] $
             for_ xs' $ \x->
-                option_ [ value_ $ decodeUtf8 $ encode x ^. strict ] $
+                option_ [ value_ $ decodeUtf8Lenient $ encode x ^. strict ] $
                     reportValueHtml x
   where
     colType    = reportValueType (Proxy :: Proxy a)

--- a/futurice-servant/src/Futurice/Servant.hs
+++ b/futurice-servant/src/Futurice/Servant.hs
@@ -67,6 +67,7 @@ import Data.Char                            (isAlpha)
 import Data.Constraint                      (Dict (..))
 import Data.Swagger                         hiding (port)
 import Data.TDigest.Metrics                 (registerTDigest)
+import Data.Text.Encoding                   (decodeLatin1)
 import Development.GitRev                   (gitCommitDate, gitHash)
 import Futurice.Cache
        (CachePolicy (..), DynMapCache, cachedIO, genCachedIO)
@@ -96,7 +97,6 @@ import System.Remote.Monitoring             (forkServer, serverMetricStore)
 
 import qualified Data.Aeson               as Aeson
 import qualified Data.Text                as T
-import qualified Data.Text.Encoding       as TE
 import qualified Data.UUID.Types          as UUID
 import qualified FUM
 import qualified Futurice.DynMap          as DynMap
@@ -288,7 +288,7 @@ futuriceServerMain' makeDict makeCtx (SC t d server middleware (I envpfx)) =
         & Warp.setPort p
         & Warp.setOnException (onException logger)
         & Warp.setOnExceptionResponse onExceptionResponse
-        & Warp.setServerName (TE.encodeUtf8 t)
+        & Warp.setServerName (encodeUtf8 t)
 
     onException logger mreq e = do
         runLogT "warp" logger $ do
@@ -331,7 +331,7 @@ instance HasServer api context => HasServer (SSOUser :> api) context where
     route Proxy context subserver =
         route (Proxy :: Proxy api) context (passToServer subserver ssoUser)
       where
-        ssoUser req = FUM.UserName . T.filter isAlpha . TE.decodeLatin1 <$>
+        ssoUser req = FUM.UserName . T.filter isAlpha . decodeLatin1 <$>
             lookup "REMOTE-USER" (requestHeaders req)
 
 instance HasLink api => HasLink (SSOUser :> api) where

--- a/planmill-client/src/PlanMill/Eval.hs
+++ b/planmill-client/src/PlanMill/Eval.hs
@@ -10,6 +10,7 @@ import PlanMill.Internal.Prelude
 import Control.Monad.Http   (MonadHttp (..), httpLbs)
 import Data.Aeson.Compat    (eitherDecode)
 import Data.TDigest.Metrics (MonadMetrics (..))
+import Data.Text.Encoding   (decodeUtf8)
 import Data.Unique          (hashUnique, newUnique)
 import Network.HTTP.Client
        (Request, RequestBody (..), method, parseRequest, path, queryString,
@@ -23,7 +24,6 @@ import qualified Data.ByteString.Char8  as BS8
 import qualified Data.ByteString.Lazy   as LBS
 import qualified Data.Map               as Map
 import qualified Data.Text              as T
-import qualified Data.Text.Encoding     as TE
 import qualified Data.Vector            as V
 
 -- PlanMill import
@@ -89,7 +89,7 @@ evalPlanMill pm = do
             writeMetric "pmreq" dur'
             if isn't _Empty (responseBody res)
                 then
-                    -- logTrace_ $ "response body: " <> TE.decodeUtf8 (responseBody res ^. strict)
+                    -- logTrace_ $ "response body: " <> decodeUtf8 (responseBody res ^. strict)
                     if statusIsSuccessful (responseStatus res)
                         then parseResult url $ responseBody res
                         else throwM $ parseError url $ responseBody res
@@ -100,7 +100,7 @@ evalPlanMill pm = do
     setQueryString' :: QueryString -> Request -> Request
     setQueryString' qs = setQueryString (f <$> Map.toList qs)
       where
-        f (a, b) = (TE.encodeUtf8 a, Just $ TE.encodeUtf8 b)
+        f (a, b) = (encodeUtf8 a, Just $ encodeUtf8 b)
 
     parseResult :: forall b .(FromJSON b) => String -> LBS.ByteString -> m b
     parseResult url body =

--- a/planmill-client/src/PlanMill/Eval.hs
+++ b/planmill-client/src/PlanMill/Eval.hs
@@ -10,7 +10,6 @@ import PlanMill.Internal.Prelude
 import Control.Monad.Http   (MonadHttp (..), httpLbs)
 import Data.Aeson.Compat    (eitherDecode)
 import Data.TDigest.Metrics (MonadMetrics (..))
-import Data.Text.Encoding   (decodeUtf8)
 import Data.Unique          (hashUnique, newUnique)
 import Network.HTTP.Client
        (Request, RequestBody (..), method, parseRequest, path, queryString,
@@ -89,7 +88,7 @@ evalPlanMill pm = do
             writeMetric "pmreq" dur'
             if isn't _Empty (responseBody res)
                 then
-                    -- logTrace_ $ "response body: " <> decodeUtf8 (responseBody res ^. strict)
+                    -- logTrace_ $ "response body: " <> decodeUtf8Lenient (responseBody res ^. strict)
                     if statusIsSuccessful (responseStatus res)
                         then parseResult url $ responseBody res
                         else throwM $ parseError url $ responseBody res

--- a/planmill-client/src/PlanMill/Internal/Prelude.hs
+++ b/planmill-client/src/PlanMill/Internal/Prelude.hs
@@ -44,7 +44,6 @@ import Futurice.Time
 import Numeric.Interval.NonEmpty (Interval, inf, sup, (...))
 
 import qualified Data.Aeson.Extra   as Aeson
-import qualified Data.Text.Encoding as TE
 
 dayFromZ :: Aeson.Z -> Day
 dayFromZ = zonedTimeDay . Aeson.getZ
@@ -53,7 +52,7 @@ zonedTimeDay :: ZonedTime -> Day
 zonedTimeDay = localDay . zonedTimeToLocalTime
 
 bsShow :: Show a => a -> ByteString
-bsShow = TE.encodeUtf8 . textShow
+bsShow = encodeUtf8 . textShow
 
 utcTimeToInteger :: UTCTime -> Integer
 utcTimeToInteger = round . utcTimeToPOSIXSeconds

--- a/planmill-client/src/PlanMill/Types/Auth.hs
+++ b/planmill-client/src/PlanMill/Types/Auth.hs
@@ -12,7 +12,6 @@ import PlanMill.Internal.Prelude
 import Futurice.EnvConfig        (FromEnvVar (..))
 
 import qualified Data.ByteString    as BS
-import qualified Data.Text.Encoding as TE
 
 
 -- | Unique 4-8 characters long string composed of upper and lower case letters
@@ -34,7 +33,7 @@ instance IsString ApiKey where
     fromString = ApiKey . fromString
 
 instance FromJSON ApiKey where
-    parseJSON = withText "Planmill apikey" $ pure . ApiKey . TE.encodeUtf8
+    parseJSON = withText "Planmill apikey" $ pure . ApiKey . encodeUtf8
 
 instance FromEnvVar ApiKey where
     fromEnvVar = fmap ApiKey . fromEnvVar

--- a/reports-app/src/Futurice/App/Reports.hs
+++ b/reports-app/src/Futurice/App/Reports.hs
@@ -26,10 +26,10 @@ import Numeric.Interval.NonEmpty ((...))
 import Prelude ()
 import Servant
 import Servant.Chart             (Chart (..))
+import Data.Text.Encode          (decodeUtf8)
 
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text            as T
-import qualified Data.Text.Encoding   as TE
 import qualified GitHub               as GH
 
 import Futurice.App.Reports.API
@@ -287,7 +287,7 @@ ctxToIntegrationsConfig now (_cache, mgr, lgr, Config {..}) = MkIntegrationsConf
 repos :: Manager -> Text -> IO [GitHubRepo]
 repos mgr url = do
     req <- parseUrlThrow $ T.unpack url
-    res <- TE.decodeUtf8 . LBS.toStrict . responseBody <$> httpLbs req mgr
+    res <- decodeUtf8 . LBS.toStrict . responseBody <$> httpLbs req mgr
     return $ mapMaybe f $ T.lines res
   where
     f line = case T.words line of

--- a/reports-app/src/Futurice/App/Reports.hs
+++ b/reports-app/src/Futurice/App/Reports.hs
@@ -26,7 +26,6 @@ import Numeric.Interval.NonEmpty ((...))
 import Prelude ()
 import Servant
 import Servant.Chart             (Chart (..))
-import Data.Text.Encode          (decodeUtf8)
 
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text            as T
@@ -287,7 +286,7 @@ ctxToIntegrationsConfig now (_cache, mgr, lgr, Config {..}) = MkIntegrationsConf
 repos :: Manager -> Text -> IO [GitHubRepo]
 repos mgr url = do
     req <- parseUrlThrow $ T.unpack url
-    res <- decodeUtf8 . LBS.toStrict . responseBody <$> httpLbs req mgr
+    res <- decodeUtf8Lenient . LBS.toStrict . responseBody <$> httpLbs req mgr
     return $ mapMaybe f $ T.lines res
   where
     f line = case T.words line of


### PR DESCRIPTION
Not sure if was required, but also replaced whole `Text.Encode` imports with a individual function import, if only the one function was needed from `Text.Encode`.