### PR TITLE
Personio client validations

### DIFF
--- a/fum-carbon-app/src/Futurice/App/FUM/Report/Validation.hs
+++ b/fum-carbon-app/src/Futurice/App/FUM/Report/Validation.hs
@@ -36,7 +36,7 @@ validationReport ctx = do
                 td_ $ toHtml _evLast
                 td_ $ toHtml $ show _evHireDate
                 td_ $ toHtml $ show _evEndDate
-                td_ $ toHtml $ show _evMessages
+                td_ $ ul_ $ traverse_ (li_ . toHtml . show) _evMessages
   where
     isCurrentEmployee today v =
         maybe True (today <=) (v ^. Personio.evEndDate) &&

--- a/personio-client/fixtures/employee.json
+++ b/personio-client/fixtures/employee.json
@@ -129,6 +129,34 @@
       "label": "Vacation day balance",
       "value": 0
     },
+    "dynamic_27160": {
+      "label": "Monthly fixed salary 100%",
+      "value": 0
+    },
+    "dynamic_27161": {
+      "label": "Monthly variable salary 100%",
+      "value": 0
+    },
+    "dynamic_27162": {
+      "label": "Hourly salary x 100",
+      "value": 0
+    },
+    "dynamic_27169": {
+      "label": "Salary currency",
+      "value": ""
+    },
+    "dynamic_27164": {
+      "label": "(SE) Occupational pension %",
+      "value": 0
+    },
+    "dynamic_27166": {
+      "label": "(SE) Holidays",
+      "value": 0
+    },
+    "dynamic_27168": {
+      "label": "(SE) Personal number",
+      "value": ""
+    },
     "dynamic_27163": {
       "label": "Work phone",
       "value": "+123 5678910"
@@ -222,7 +250,15 @@
       "value": ""
     },
     "dynamic_72970": {
-      "label": "Expat bonus",
+      "label": "Expat monthly bonus 100%",
+      "value": ""
+    },
+    "dynamic_72971": {
+      "label": "Expat housing allowance",
+      "value": ""
+    },
+    "dynamic_72972": {
+      "label": "Expat bonus and allowance currency",
       "value": ""
     },
     "dynamic_66601": {
@@ -266,11 +302,15 @@
       "value": ""
     },
     "dynamic_72946": {
-      "label": "Local / Expat",
-      "value": "local"
+      "label": "Expat",
+      "value": "No"
     },
     "dynamic_72949": {
-      "label": "End of expat assignment",
+      "label": "End of assignment",
+      "value": ""
+    },
+    "dynamic_72950": {
+      "label": "Start of assignment",
       "value": ""
     },
     "dynamic_72943": {
@@ -278,8 +318,24 @@
       "value": "SomeTribe"
     },
     "dynamic_72916": {
-      "label": "Home address",
-      "value": "Otakaari 1, Espoo"
+      "label": "Home street address",
+      "value": "Otakaari 1"
+    },
+    "dynamic_72917": {
+      "label": "Home postal code",
+      "value": "02150"
+    },
+    "dynamic_72918": {
+      "label": "Home city",
+      "value": "Espoo"
+    },
+    "dynamic_72920": {
+      "label": "Home country",
+      "value": "Finland"
+    },
+    "dynamic_72921": {
+      "label": "Private email",
+      "value": "eskokarvinen85@suomi24.fi"
     },
     "dynamic_72934": {
       "label": "Health insurance",
@@ -292,6 +348,18 @@
     "dynamic_72936": {
       "label": "Home phone",
       "value": "+123 5678910"
+    },
+    "dynamic_72938": {
+      "label": "Private phone",
+      "value": "+123 5678910"
+    },
+    "dynamic_72939": {
+      "label": "Emergency contact phone",
+      "value": "+123 5678910"
+    },
+    "dynamic_72941": {
+      "label": "(GB) National Insurance Number",
+      "value": ""
     }
   }
 }

--- a/personio-client/package.yaml
+++ b/personio-client/package.yaml
@@ -36,6 +36,7 @@ dependencies:
   - mtl
   - regex-applicative
   - regex-applicative-text
+  - scientific
   - swagger2
   - text
   - time

--- a/personio-client/personio-client.cabal
+++ b/personio-client/personio-client.cabal
@@ -50,6 +50,7 @@ library
     , mtl
     , regex-applicative
     , regex-applicative-text
+    , scientific
     , swagger2
     , text
     , time
@@ -62,6 +63,7 @@ library
       Personio.Types
       Personio.Types.ContractType
       Personio.Types.EmploymentType
+      Personio.Types.PersonalIdValidations
       Personio.Types.Status
   default-language: Haskell2010
 
@@ -93,6 +95,7 @@ test-suite unit-tests
     , mtl
     , regex-applicative
     , regex-applicative-text
+    , scientific
     , swagger2
     , text
     , time

--- a/personio-client/src/Personio/Types.hs
+++ b/personio-client/src/Personio/Types.hs
@@ -828,7 +828,7 @@ validatePersonioEmployee = withObjectDump "Personio.Employee" $ \obj -> do
         homeTribeValidate :: WriterT [ValidationMessage] Parser()
         homeTribeValidate = do
             hTribe <- lift (parseDynamicAttribute obj "Home tribe")
-            case tribeFromText hTribe of
+            unless (hTribe == "") $ case tribeFromText hTribe of
                 Just _  -> pure ()
                 Nothing -> tell [HomeTribeInvalid hTribe]
 

--- a/personio-client/src/Personio/Types/PersonalIdValidations.hs
+++ b/personio-client/src/Personio/Types/PersonalIdValidations.hs
@@ -1,0 +1,308 @@
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+module Personio.Types.PersonalIdValidations (
+    isValidFinSSN,
+    isValidGbNINO,
+    isValidSwePIN,
+    isValidDeSV,
+    isValidDeID
+    ) where
+
+import Data.Maybe                  (isJust)
+import Text.Regex.Applicative.Text (match, psym)
+
+import Futurice.Prelude
+
+import qualified Data.HashMap.Strict as HM
+import qualified Data.List           as L
+import qualified Data.Text           as T
+
+unconsN :: Maybe [a] -> Int -> (Maybe [a], Maybe [a])
+unconsN Nothing _    = (Nothing, Nothing)
+unconsN (Just xs) n = if length xs < n
+    then (Nothing, Nothing)
+    else (Just $ take n xs, Just $ drop n xs)
+
+textRegexp 
+    :: Int    -- ^ min and max
+    -> String -- ^ valid characters 
+    -> Text   -- ^ to validate
+    -> Maybe String
+textRegexp m vChars = match $ range m m (psym (`elem` vChars))
+  where
+    range
+        :: Alternative f
+        => Int  -- ^ min
+        -> Int  -- ^ max
+        -> f a
+        -> f [a]
+    range mi ma f = go mi ma
+      where
+        go start end
+            | start > end || end <= 0 = pure []
+            | start > 0 = (:) <$> f <*> go (start - 1) (end - 1)
+            | otherwise = inRange <$> optional f <*> go 0 (end - 1)
+
+        inRange current next = maybe [] (:next) current
+
+validateRange :: Maybe String -> Int -> Int -> Bool
+validateRange date mini maxi = case date of
+    Nothing -> False
+    Just v  -> between v mini maxi
+  where
+    between d mi ma = case readMaybe d :: Maybe Int of
+        Nothing -> False
+        Just v  -> v >= mi && v <= ma
+    
+charsToDigits :: (Read a, Integral a) => String -> Maybe [a]
+charsToDigits cs = flipMaybe $ map (readMaybe . (:[])) cs
+  where
+    flipMaybe :: [Maybe a] -> Maybe [a]
+    flipMaybe mbs = 
+        let catted = catMaybes mbs
+        in if length catted == length mbs
+            then Just catted
+            else Nothing
+
+numToDigits :: Integral a => a -> [a]
+numToDigits = reverse . L.unfoldr f
+  where
+    f d 
+        | d >= 10   = Just (mod d 10, div d 10)
+        | d > 0     = Just (d, 0)
+        | otherwise = Nothing
+
+-- | Validate Swedish Personal Identity Number
+-- 
+-- See <https://en.wikipedia.org/wiki/Personal_identity_number_(Sweden)>
+isValidSwePIN :: Text -> Bool
+isValidSwePIN p = foldr (&&) True [ validateRange (fst yer) 1900 9999
+                                  , validateRange (fst mnt) 1 12 -- validate month
+                                  , validateRange (fst day) 1 31 -- validate day
+                                  , validateChecksum pin
+                                  ]
+  where
+    validChars = '-':['0'..'9']
+    pin = textRegexp 13 validChars p -- 12 characters and "-" between date and identifier
+    yer = unconsN pin 4
+    mnt = unconsN (snd yer) 2
+    day = unconsN (snd mnt) 2
+
+    validateChecksum piNum = case piNum of
+        Just p' -> luhnValidation . charsToDigits $ drop 2 $ filter (/= '-') p'
+        Nothing -> False
+
+    -- | Luhn validation
+    --
+    -- See <https://en.wikipedia.org/wiki/Luhn_algorithm>
+    luhnValidation :: Maybe [Int] -> Bool
+    luhnValidation mDigits = case mDigits of
+        Nothing -> False
+        Just ds -> 
+            let checkS = last ds
+                summed = sum . doubleOdd . reverse $ init ds
+            in mod (summed * 9) 10 == checkS
+      where
+        doubleOdd ds = foldr f [] $ L.zip [1..] ds
+          where
+            f :: (Int, Int) -> [Int] -> [Int]
+            f (i, d) rest
+                | even i = d : rest
+                | otherwise = (sum . numToDigits) (2 * d) : rest
+        
+-- | Validate Finnish Social Security Number
+--
+-- See <https://en.wikipedia.org/wiki/National_identification_number#Finland>
+isValidFinSSN :: Text -> Bool
+isValidFinSSN snn = foldr (&&) True [ validateRange (fst day) 1 31 -- Validate day
+                                    , validateRange (fst mnt) 1 12 -- Validate month
+                                    , validateRange (fst yer) 0 99 -- Validate year
+                                    , validateCenturyId (fst cid)
+                                    , validateRange (fst pid) 0 899 -- validate personal identifier
+                                    , validateChecksumId (fst date, fst pid) (fst sid)
+                                    ]
+  where
+    date = unconsN (textRegexp 11 validChars $ T.toUpper $ T.filter (/= ' ') snn) 6
+    day = unconsN (fst date) 2
+    mnt = unconsN (snd day) 2
+    yer = unconsN (snd mnt) 2
+    cid = unconsN (snd date) 1
+    pid = unconsN (snd cid) 3
+    sid = unconsN (snd pid) 1
+
+    validateCenturyId :: Maybe String -> Bool
+    validateCenturyId cId = case cId of
+        Nothing -> False
+        Just i  -> head i `elem` validCentIds
+
+    toDigit :: Char -> Maybe Integer
+    toDigit c = maybeFromIntegral $ L.elemIndex c validANums
+      where
+        maybeFromIntegral :: (Integral a, Num b) => Maybe a -> Maybe b
+        maybeFromIntegral (Just v) = Just $ fromIntegral v
+        maybeFromIntegral _        = Nothing
+
+    validateChecksumId :: (Maybe String, Maybe String) -> Maybe String -> Bool
+    validateChecksumId (Just dt, Just pId) (Just checkS) = 
+        case readMaybe (dt ++ pId) :: Maybe Integer of
+            Nothing -> False
+            Just d  -> case toDigit (head checkS) of
+                Nothing -> False
+                Just v  -> v == mod d 31 
+    validateChecksumId _ _ = False 
+
+    validANums = concat [ ['0'..'9']
+                        , ['A'..'F']
+                        , ['H']
+                        , ['J'..'N']
+                        , ['P']
+                        , ['R'..'Y']
+                        ]
+    validCentIds = ['+', '-', 'A']
+
+    validChars = validANums ++ validCentIds
+
+-- | Validate (GB) National Insurance Number
+--
+-- See <https://www.gov.uk/hmrc-internal-manuals/national-insurance-manual/nim39110>
+isValidGbNINO :: Text -> Bool
+isValidGbNINO nino = foldr (&&) True [ validatePrefix (fst pre)
+                                     , validateMiddle (fst mid)
+                                     , validateSuffix (fst suf)
+                                     ]
+  where
+    validChars = validLetters ++ ['0'..'9']
+    nin = textRegexp 9 validChars $ T.toUpper $ T.filter (/= ' ') nino
+    pre = unconsN nin 2
+    mid = unconsN (snd pre) 6
+    suf = unconsN (snd mid) 1
+
+    validatePrefix :: Maybe String -> Bool
+    validatePrefix pref = case pref of
+        Nothing -> False
+        Just p  -> isJust (textRegexp 2 validPreLetters (T.pack p)) 
+                   && last p /= 'O'
+                   && p `notElem` ["BG", "GB", "KN", "NK", "NT", "TN", "ZZ"]
+      where
+        validPreLetters = 
+            filter (`notElem` ['D', 'F', 'I', 'Q', 'U', 'V']) validLetters
+
+    validateMiddle :: Maybe String -> Bool
+    validateMiddle middle = case middle of
+        Nothing -> False
+        Just m  -> isJust $ textRegexp 6 ['0'..'9'] $ T.pack m
+
+    validateSuffix :: Maybe String -> Bool
+    validateSuffix suff = case suff of
+        Nothing -> False
+        Just s  -> isJust $ textRegexp 1 validLetters $ T.pack s
+
+    validLetters = ['A'..'Z']
+
+-- | Validate (DE) Social security number 
+-- 
+-- See <https://www.financescout24.de/wissen/ratgeber/sozialversicherungsnummer#aufbau>
+isValidDeSV :: Text -> Bool
+isValidDeSV sv = foldr (&&) True [ validateRange (fst day) 1 31 
+                                 , validateRange (fst mnt) 1 12
+                                 , validateRange (fst yer) 0 99
+                                 , validInitial (fst ini)
+                                 , checksum $ initialToDigit svn (fst ini)
+                                 ]
+  where
+    validLetters = ['A'..'Z']
+    validChars = ['0'..'9'] ++ validLetters
+    svn = textRegexp 12 validChars $ T.toUpper $ T.filter (/= ' ') sv
+    pns = unconsN svn 2 -- responsible pension insurer
+    day = unconsN (snd pns) 2
+    mnt = unconsN (snd day) 2
+    yer = unconsN (snd mnt) 2
+    ini = unconsN (snd yer) 1
+
+    validInitial :: Maybe String -> Bool
+    validInitial initial = case initial of
+        Nothing -> False
+        Just i  -> head i `elem` validLetters
+
+    initialToDigit :: Maybe String -> Maybe String -> Maybe [Integer]
+    initialToDigit (Just svNum) (Just initial) = case (pre, mid, suf) of
+        (Just p, Just m, Just s) -> Just $ p ++ m ++ s
+        _                        -> Nothing
+      where
+        mid = maybe Nothing f (L.elemIndex (head initial) ['A'..'Z'])
+          where
+            f x = if x + 1 > 9
+                then Just $ (numToDigits . fromIntegral) (x + 1)
+                else Just [0, fromIntegral (x + 1)]
+        pre = charsToDigits (take 8 svNum)
+        suf = charsToDigits (drop 9 svNum)
+    initialToDigit _ _ = Nothing
+
+    checksum :: Maybe [Integer] -> Bool
+    checksum digits = 
+        case digits of
+            Nothing -> False
+            Just ds -> 
+                let checkD = last ds
+                in mod (summed ds) 10 == checkD
+      where
+        summed ds = sum $ map (sum . numToDigits) $ L.zipWith (*) (init ds) multipliers
+        multipliers = [2, 1, 2, 5, 7, 1, 2, 1, 2, 1, 2, 1]
+
+-- | Validate (DE) ID number
+-- 
+-- See <https://de.wikipedia.org/wiki/Steuerliche_Identifikationsnummer#Aufbau_der_Identifikationsnummer>
+-- and <http://www1.osci.de/sixcms/media.php/13/Pr%FCfziffernberechnung.pdf>
+isValidDeID :: Text -> Bool
+isValidDeID deId = foldr (&&) True [ validInitial $ fst initial
+                                   , oneTwiceOrThrice occurred
+                                   , allLeqThrice occurred
+                                   , validateChecksum dId 
+                                   ]
+  where
+    dId = maybe Nothing charsToDigits $ textRegexp 11 ['0'..'9'] $ T.filter (/= ' ') deId
+    initial = unconsN dId 1
+    noCheckS = unconsN dId 10
+    occurred = case fst noCheckS of
+        Just ds -> HM.toList $ HM.fromListWith (+) [(c, 1) | c <- ds]
+        _       -> []
+
+    allLeqThrice :: [(Integer, Integer)] -> Bool
+    allLeqThrice ocrd = not (any f ocrd)
+      where
+        f (_, n) = n > 3
+
+    oneTwiceOrThrice :: [(Integer, Integer)] -> Bool
+    oneTwiceOrThrice ocrd = length (filter f ocrd) == 1
+      where
+        f (_, n) = 3 == n || n == 2
+
+    validInitial :: Maybe [Integer] -> Bool
+    validInitial ds = case ds of
+        Just [x] -> x /= 0
+        _        -> False
+        
+    validateChecksum :: Maybe [Integer] -> Bool
+    validateChecksum digits = case digits of
+        Nothing -> False
+        Just ds -> checksum (init ds) == last ds
+
+    checksum :: [Integer] -> Integer
+    checksum digits = checkCipher
+      where
+        n = 11
+        m = 10
+        checkCipher = if n - prdct == 10 then 0 else n - prdct
+        prdct = foldl prdctCount m digits
+        
+        prdctCount
+            :: Integer -- cipher
+            -> Integer -- old product
+            -> Integer -- new product
+        prdctCount cipher prd = mod (2 * sm cipher prd) n
+
+        sm cipher prd = let s = mod (cipher + prd) m
+                        in if s == 0 then m else s

--- a/personio-client/tests/Tests.hs
+++ b/personio-client/tests/Tests.hs
@@ -19,6 +19,11 @@ main = defaultMain $ testGroup "tests"
     [ properties
     , examples
     , isValidIBANTests
+    , isValidFinSSNTests
+    , isValidSwePINTests
+    , isValidGbNINOTests
+    , isValidDeSVTests
+    , isValidDeId
     ]
 
 -------------------------------------------------------------------------------
@@ -88,11 +93,6 @@ validations = testGroup "Validations"
             & attributeValue "dynamic_72913" . _String
                 .~ "http://github.com/gitMastur"
     , testValidation
-        "email"
-        EmailMissing
-        $ correctEmployeeValue
-            & attributeValue "email" .~  Array mempty
-    , testValidation
         "tribe"
         TribeMissing
         $ correctEmployeeValue
@@ -140,29 +140,240 @@ validations = testGroup "Validations"
         "fixed-term contract_end_date"
         FixedTermEndDateMissing
         $ correctEmployeeValue
-            & attributeValue "dynamic_72935" . _String .~  "fixed term"
+            & attributeValue "dynamic_72935" . _String .~  "fixed term" -- contract type
             & attributeValue "contract_end_date" .~ Null
     , testValidation
         "permanent external"
         PermanentExternal
         $ correctEmployeeValue
-            & attributeValue "dynamic_72935" . _String .~ "permanent"
+            & attributeValue "dynamic_72935" . _String .~ "permanent" -- contract type
             & attributeValue "employment_type" . _String .~ "external"
     , testValidation
         "home phone"
-        HomePhoneInvalid
+        (HomePhoneInvalid "123a4")
         $ correctEmployeeValue
             & attributeValue "dynamic_72936" . _String .~ "123a4"
     , testValidation
         "flowdock"
         FlowdockInvalid
         $ correctEmployeeValue
-            & attributeValue "dynamic_72914" . _String .~ "https://www.flowdock.com/12345"
+            & attributeValue "dynamic_72914" . _String .~ "https://www.flowdock.com/12345" -- flowdock
+    , testValidation
+        "first name"
+        FirstNameMissing
+        $ correctEmployeeValue
+            & attributeValue "first_name" . _String .~ ""
+    , testValidation
+        "last name"
+        LastNameMissing
+        $ correctEmployeeValue
+            & attributeValue "last_name" . _String .~ ""
+    , testValidation
+        "gender"
+        GenderMissing
+        $ correctEmployeeValue
+            & attributeValue "gender" . _String .~ ""
+    , testValidation
+        "email"
+        (EmailInvalid "invalid.mail")
+        $ correctEmployeeValue
+            & attributeValue "email" . _String .~ "invalid.mail"
+    , testValidation
+        "position"
+        PositionMissing
+        $ correctEmployeeValue
+            & attributeValue "position" . _String .~ ""
+    , testValidation
+        "hire-date"
+        HireDateMissing
+        $ correctEmployeeValue
+            & attributeValue "hire_date" .~ Null
+    , testValidation
+        "supervisor"
+        SupervisorMissing
+        $ correctEmployeeValue
+            & attributeValue "supervisor" .~ Array mempty
+    , testValidation
+        "weekly hours"
+        (HoursInvalid 0)
+        $ correctEmployeeValue
+            & attributeValue "weekly_working_hours" . _String .~ "0"
+    , testValidation
+        "contract type"
+        ContractTypeMissing
+        $ correctEmployeeValue
+            & attributeValue "dynamic_72935" . _String .~ "" -- Contract type
+    , testValidation
+        "nationality"
+        NationalityMissing
+        $ correctEmployeeValue
+            & attributeValue "employment_type" . _String .~ "internal"
+            & attributeValue "dynamic_66601" . _String .~ "" -- Nationality
+    , testValidation
+        "work permit"
+        WorkPermitMissing
+        $ correctEmployeeValue
+            & attributeValue "employment_type" . _String .~ "internal"
+            & attributeValue "dynamic_66604" . _String .~ "" -- Work permit
+    , testValidation
+        "work permit ends"
+        WorkPermitEndsMissing
+        $ correctEmployeeValue
+            & attributeValue "dynamic_66604" . _String .~ "temporary" -- Work permit
+            & attributeValue "dynamic_72937" .~ Null  -- Work permit ends
+    , testValidation
+        "career path level"
+        CareerPathLevelMissing
+        $ correctEmployeeValue
+            & attributeValue "employment_type" . _String .~ "internal"
+            & attributeValue "dynamic_72940" .~ Null -- Career path level
+    , testValidation
+        "home street address"
+        HomeStreetAddressMissing
+        $ correctEmployeeValue
+          & attributeValue "dynamic_72916" . _String .~ "" -- Home street address
+    , testValidation
+        "home city"
+        HomeCityMissing
+        $ correctEmployeeValue
+          & attributeValue "dynamic_72918" . _String .~ "" -- Home city
+    , testValidation
+        "private email"
+        (PrivateEmailInvalid "eskokarvinen@fi")
+        $ correctEmployeeValue
+            & attributeValue "dynamic_72921" . _String .~ "eskokarvinen@fi" -- private email
+    , testValidation
+        "private phone"
+        (PrivatePhoneInvalid "1234")
+        $ correctEmployeeValue
+            & attributeValue "dynamic_72938" . _String .~ "1234" -- private phone
+    , testValidation
+        "emergency contact phone"
+        (EmergencyContactPhoneInvalid "1234")
+        $ correctEmployeeValue
+            & attributeValue "dynamic_72939" . _String .~ "1234" -- Emergency contact phone
+    , testValidation
+        "expat"
+        ExpatMissing
+        $ correctEmployeeValue
+            & attributeValue "dynamic_72946" . _String .~ "" -- Expat
+    , testValidation
+        "start of assignment"
+        StartOfExpatAssignmentMissing
+        $ correctEmployeeValue
+            & attributeValue "dynamic_72946" . _String .~ "Yes" -- Expat
+            & attributeValue "dynamic_72950" . _String .~ "" -- Start of assignment
+    , testValidation
+        "end of assignment"
+        EndOfExpatAssignmentMissing
+        $ correctEmployeeValue
+            & attributeValue "dynamic_72946" . _String .~ "Yes" -- Expat
+            & attributeValue "dynamic_72949" . _String .~ "" -- End of assignment
+    , testValidation
+        "home tribe"
+        (HomeTribeInvalid "SomeTribe")
+        $ correctEmployeeValue
+            & attributeValue "dynamic_72943" . _String .~ "SomeTribe" -- Home tribe
+    , testValidation
+        "expat bonus and allowance currency" 
+        ExpatBonusAndAllowanceCurrencyMissing
+        $ correctEmployeeValue
+            & attributeValue "dynamic_72971" . _String .~ "something?" -- Expat housing allowance
+            & attributeValue "dynamic_72972" . _String .~ "" -- Expat bonus and allowance currency
+    , testValidation
+        "salary"
+        (SalaryInvalid "monthly fixed: False, hourly: False")
+        $ correctEmployeeValue
+            & attributeValue "employment_type" . _String .~ "internal"
+            & attributeValue "dynamic_27160" .~ Number 0 -- Monthly fixed salary 100%
+            & attributeValue "dynamic_27162" .~ Number 0 -- Hourly salary x 100
+    , testValidation
+        "monthly variable salary"
+        ExternalMonthlyVariableSalary
+        $ correctEmployeeValue
+            & attributeValue "employment_type" . _String .~ "external"
+            & attributeValue "dynamic_27161" .~ Number 42 -- Monthly variable salary 100%
+    , testValidation
+        "(SE) occupational pension %"
+        (SEPensionInvalid (negate 1))
+        $ correctEmployeeValue
+            & attributeValue "employment_type" . _String .~ "internal"
+            & attributeValue "dynamic_66601" . _String .~ "Sweden" -- Nationality
+            & attributeValue "dynamic_27164" .~ Number (negate 1) -- (SE) Occupational pension %
+    , testValidation
+        "(SE) Holidays"
+        (SEHolidaysInvalid 0)
+        $ correctEmployeeValue
+            & attributeValue "employment_type" . _String .~ "internal"
+            & attributeValue "dynamic_66601" . _String .~ "Sweden" -- Nationality
+            & attributeValue "dynamic_27166" .~ Number 0 -- (SE) Holidays
+    , testValidation
+        "HR number"
+        (HRNumberInvalid 0)
+        $ correctEmployeeValue
+            & attributeValue "dynamic_66136" .~ Number 0 -- HR number
+    , testValidation
+       "(FI) social security number"
+       FISSNInvalid
+       $ correctEmployeeValue
+           & attributeValue "dynamic_65812" . _String .~ "120464-126A" -- (FI) Social Security Number
+    , testValidation
+        "(SE) Personal number"
+        SEPersonalIdInvalid
+        $ correctEmployeeValue
+            & attributeValue "dynamic_27168" . _String .~ "17001228-9U74" -- (SE) Personal number
+    , testValidation
+        "(GB) National Insurance Number"
+        GBNINOInvalid
+        $ correctEmployeeValue
+            & attributeValue "dynamic_72941" . _String .~ "QQ 12 34 56 A" -- (GB) National Insurance Number
+    , testValidation
+        "(DE) Social security number (SV)"
+        DESVInvalid
+        $ correctEmployeeValue
+            & attributeValue "dynamic_72931" . _String .~ "120308664019" -- (DE) Social security number (SV)
+    , testValidation
+        "(DE) ID number"
+        DEIDInvalid
+        $ correctEmployeeValue
+            & attributeValue "dynamic_72928" . _String .~ "11222345671" -- (DE) ID number
+    , testValidation
+        "Salary currency"
+        (SalaryCurrencyInvalid "ZWD")
+        $ correctEmployeeValue
+            & attributeValue "dynamic_27169" . _String .~ "ZWD" -- Salary currency
+    , testValidation
+        "Home country"
+        HomeCountryMissing
+        $ correctEmployeeValue
+            & attributeValue "dynamic_72920" . _String .~ "" -- Home country
+    , testValidation
+        "Personal identification number"
+        IdentificationNumberMissing
+        $ correctEmployeeValue
+            & attributeValue "dynamic_72931" . _String .~ "" -- (DE) Social security number (SV)
+            & attributeValue "dynamic_72941" . _String .~ "" -- (GB) National Insurance Number
+            & attributeValue "dynamic_27168" . _String .~ "" -- (SE) Personal number
+            & attributeValue "dynamic_65812" . _String .~ "" -- (FI) Social Security Number
     ]
   where
     testValidation name warning val = testCase name $ do
         ev <- either fail pure $ parseEither validatePersonioEmployee val
         assertBool (show ev) $ warning `elem` ev ^. evMessages
+
+
+
+validValue :: Show a => (a -> Bool) -> a ->  TestTree
+validValue checker toCheck = testCase msg $
+    assertBool "invalid!" $ checker toCheck
+  where 
+    msg = show toCheck ++ " is valid"
+
+invalidValue :: Show a => (a -> Bool) -> a -> TestTree
+invalidValue checker toCheck = testCase msg $
+    assertBool "valid!" $ not $ checker toCheck
+  where 
+    msg = show toCheck ++ " is invalid"
 
 -------------------------------------------------------------------------------
 -- IBAN
@@ -178,9 +389,103 @@ isValidIBANTests = testGroup "isValidIBAN"
     ]
   where
     validIBAN :: Text -> TestTree
-    validIBAN iban = testCase (iban ^. unpacked ++ " is valid") $
-        assertBool "invalid!" $ isValidIBAN iban
+    validIBAN = validValue isValidIBAN 
 
     invalidIBAN :: Text -> TestTree
-    invalidIBAN iban = testCase (iban ^. unpacked ++ " is invalid") $
-        assertBool "valid!" $ not $ isValidIBAN iban
+    invalidIBAN = invalidValue isValidIBAN
+
+-------------------------------------------------------------------------------
+-- Finnish SSN
+-------------------------------------------------------------------------------
+
+isValidFinSSNTests :: TestTree
+isValidFinSSNTests = testGroup "isValidFinSSN"
+    [ validSSN "120464-126J"
+    , invalidSSN "1204-126J" -- too short
+    , invalidSSN "12041964-126J" -- too long
+    , invalidSSN "420464-126J" -- invalid day
+    , invalidSSN "121364-126J" -- invalid month
+    , invalidSSN "1204A9-126J" -- invalid year
+    , invalidSSN "120464*126J" -- invalid century identifier
+    , invalidSSN "120464-901J" -- invalid personal identifier
+    , invalidSSN "120464-126A" -- invalid checksum-identifier
+    ]
+  where
+    validSSN :: Text -> TestTree
+    validSSN = validValue isValidFinSSN
+
+    invalidSSN :: Text -> TestTree
+    invalidSSN = invalidValue isValidFinSSN
+
+isValidSwePINTests :: TestTree
+isValidSwePINTests = testGroup "isValidSwePIN"
+    [ validPIN "19811228-9874"
+    , validPIN "19670919-9530"
+    , invalidPIN "1981122-8987" -- too short
+    , invalidPIN "199811228-9874" -- too long
+    , invalidPIN "18911228-9874" -- invalid year
+    , invalidPIN "19814228-9874" -- invalid month
+    , invalidPIN "19811242-9874" -- invalid day
+    , invalidPIN "19811228-9424" -- invalid personal identifier
+    , invalidPIN "19811228-9878" -- invalid checksum-number
+    ]
+  where
+    validPIN :: Text -> TestTree
+    validPIN = validValue isValidSwePIN
+
+    invalidPIN :: Text -> TestTree
+    invalidPIN = invalidValue isValidSwePIN
+
+isValidGbNINOTests :: TestTree
+isValidGbNINOTests = testGroup "isValidGbNINO"
+    [ validNINO "AE 12 34 56 A"
+    , invalidNINO "AE 12 34 56" -- invalid length
+    , invalidNINO "27 12 34 56 A" -- starting characters are not letters
+    , invalidNINO "AE 12 E4 56 A" -- invalid date numbers
+    , invalidNINO "AE 12 34 56 7" -- invalid suffix letter
+    , invalidNINO "QD 12 34 56 A" -- D, F, I, Q, U, and V should not be used as either the first or second letter
+    , invalidNINO "AO 12 34 56 A" -- The letter O should not be used as the second letter of a prefix
+    , invalidNINO "BG 12 34 56 A" -- Prefixes BG, GB, KN, NK, NT, TN and ZZ should not be used
+    ]
+  where
+    validNINO :: Text -> TestTree
+    validNINO = validValue isValidGbNINO
+
+    invalidNINO :: Text -> TestTree
+    invalidNINO = invalidValue isValidGbNINO
+
+isValidDeSVTests :: TestTree
+isValidDeSVTests = testGroup "isValidDeSV"
+    [ validSV "12030866A019"
+    , invalidSV "12030866A08" -- too short
+    , invalidSV "1203081966A019" -- too long
+    , invalidSV "12420866A012" -- invalid day
+    , invalidSV "12034266A013" -- invalid month
+    , invalidSV "120308E3A011" -- invalid year
+    , invalidSV "120308664017" -- invalid name initial
+    , invalidSV "12030866A012" -- invalid checksum
+    ]
+  where
+    validSV :: Text -> TestTree
+    validSV = validValue isValidDeSV
+
+    invalidSV :: Text -> TestTree
+    invalidSV = invalidValue isValidDeSV
+
+isValidDeId :: TestTree
+isValidDeId = testGroup "isValidDeID"
+    [ validID "10234567783"
+    , invalidID "01234567896" -- 0 in beginning
+    , invalidID "123456789014" -- too long
+    , invalidID "1234567897" -- too short
+    , invalidID "11112245672" -- digit appears more than thrice
+    , invalidID "11222345671" -- more than one digits appear more than once
+    , invalidID "12345678903" -- none appears twice or thrice
+    , invalidID "10234567782" -- invalid checksum
+    ]
+  where
+    validID :: Text -> TestTree
+    validID = validValue isValidDeID
+
+    invalidID :: Text -> TestTree
+    invalidID = invalidValue isValidDeID


### PR DESCRIPTION
Most of the validations assume that labels of dynamic values correspond the fields seen in a Personio profile. Would be great to check.

Fields not yet validated:

- Monthly fixed salary 100%
  - requires better specifications to validate
- Monthly variable salary 100%
  - will do tomorrow
- Hourly salary x 100
  - requires better specifications to validate

Following looks like a lot of hassle. Do we want to validate these?
- (SE) Occupational pension %
- (SE) Holidays
- BIC
- (FI) Social Security Number
- (DE) ID number
- (DE) Social security number (SV)
- (GB) National Insurance Number
- (SE) Personal number
- Home postal code
  - Some countries do not even use, and most countries have different valid codes
- Home supervisor
  - cannot be validated here?





