### PR TITLE
Improve task sorting in checklist page

### DIFF
--- a/checklist-app/checklist-app.cabal
+++ b/checklist-app/checklist-app.cabal
@@ -35,6 +35,7 @@ library
     , adjunctions
     , aeson
     , aeson-compat
+    , algebraic-graphs
     , ansi-pretty
     , ansi-wl-pprint
     , async
@@ -78,6 +79,7 @@ library
     , regex-applicative
     , resource-pool
     , servant
+    , servant-algebraic-graphs
     , servant-Chart
     , servant-lucid
     , servant-server

--- a/checklist-app/src/Futurice/App/Checklist/API.hs
+++ b/checklist-app/src/Futurice/App/Checklist/API.hs
@@ -10,7 +10,7 @@ import Futurice.Servant          (SSOUser)
 import Servant.API
 import Servant.Chart             (Chart, SVG)
 import Servant.HTML.Lucid        (HTML)
-
+import Servant.Graph             (ALGAPNG, Graph)
 import Futurice.App.Checklist.Ack     (Ack)
 import Futurice.App.Checklist.Command (Command)
 import Futurice.App.Checklist.Types
@@ -28,6 +28,7 @@ type ChecklistAPI = IndexPageEndpoint
     :<|> CreateEmployeePageEndpoint
     -- Items
     :<|> ChecklistPageEndpoint
+    :<|> ChecklistGraphEndpoint
     :<|> TaskPageEndpoint
     :<|> EmployeePageEndpoint
     :<|> EmployeeAuditPageEndpoint
@@ -101,6 +102,13 @@ type ChecklistPageEndpoint =
     "checklists" :>
     Capture "checklist-id" ChecklistId :>
     Get '[HTML] (HtmlPage "checklist")
+
+type ChecklistGraphEndpoint =
+    SSOUser :>
+    "checklists" :>
+    Capture "checklist-id" ChecklistId :>
+    "task-graph.png" :>
+    Get '[ALGAPNG] (Graph Text "checklist")
 
 type TaskPageEndpoint =
     SSOUser :>
@@ -200,6 +208,9 @@ createEmployeePageEndpoint = Proxy
 
 checklistPageEndpoint :: Proxy ChecklistPageEndpoint
 checklistPageEndpoint = Proxy
+
+checklistGraphEndpoint :: Proxy ChecklistGraphEndpoint
+checklistGraphEndpoint = Proxy
 
 taskPageEndpoint :: Proxy TaskPageEndpoint
 taskPageEndpoint = Proxy

--- a/checklist-app/src/Futurice/App/Checklist/Markup.hs
+++ b/checklist-app/src/Futurice/App/Checklist/Markup.hs
@@ -17,6 +17,7 @@ module Futurice.App.Checklist.Markup (
     createTaskPageHref,
     createEmployeePageHref,
     checklistPageHref,
+    checklistGraphSrc,
     taskPageHref,
     employeePageHref,
     applianceHelpHref,
@@ -214,6 +215,10 @@ employeePageHref e =
 checklistPageHref :: ChecklistId -> Attribute
 checklistPageHref cid =
     href_ $ linkToText $ safeLink checklistApi checklistPageEndpoint cid
+
+checklistGraphSrc :: ChecklistId -> Attribute
+checklistGraphSrc cid =
+    src_ $ linkToText $ safeLink checklistApi checklistGraphEndpoint cid
 
 applianceHelpHref :: Attribute
 applianceHelpHref = href_ $ linkToText $ safeLink checklistApi applianceHelpEndpoint

--- a/checklist-app/src/Futurice/App/Checklist/Pages/Checklist.hs
+++ b/checklist-app/src/Futurice/App/Checklist/Pages/Checklist.hs
@@ -110,7 +110,7 @@ checklistPage world today authUser checklist = checklistPage_ (view nameText che
 
 
   where
-    tasks0 = world ^.. worldTasksSorted (authUser ^. authUserTaskRole) . folded
+    tasks0 = world ^.. worldTasksSortedByOffset (authUser ^. authUserTaskRole) . folded
     tasks = filter (\task -> checklist ^. checklistTasks . contains (task ^. identifier)) tasks0
 
     mcid = checklist ^? checklistId

--- a/checklist-app/src/Futurice/App/Checklist/Pages/Checklist.hs
+++ b/checklist-app/src/Futurice/App/Checklist/Pages/Checklist.hs
@@ -110,7 +110,7 @@ checklistPage world today authUser checklist = checklistPage_ (view nameText che
 
 
   where
-    tasks0 = world ^.. worldTasksSortedByOffset (authUser ^. authUserTaskRole) . folded
+    tasks0 = world ^.. worldTasksSorted (authUser ^. authUserTaskRole) . folded
     tasks = filter (\task -> checklist ^. checklistTasks . contains (task ^. identifier)) tasks0
 
     mcid = checklist ^? checklistId

--- a/checklist-app/src/Futurice/App/Checklist/Pages/Index.hs
+++ b/checklist-app/src/Futurice/App/Checklist/Pages/Index.hs
@@ -188,7 +188,7 @@ indexPage world today authUser@(_fu, _viewerRole) integrationData mloc mlist mta
                             when (task ^. taskComment) $ td_ $ taskCommentInput_ world employee task
                             for_ (closure (world ^. worldTasks) (task ^.. taskPrereqs . folded)) $ \prereqTasks ->
                                 td_ $ unless (null prereqTasks) $
-                                    ul_ [ class_ "no-bullet" ] $ for_ prereqTasks $ \prereqTask ->
+                                    ul_ [ class_ "no-bullet" ] $ for_ (prereqTasks ^. tasksSorted world) $ \prereqTask ->
                                         for_ (world ^? worldTaskItems . ix eid . ix (prereqTask ^. identifier)) $ \_ ->
                                             li_ $ shortTaskCheckbox_ world employee prereqTask
 

--- a/checklist-app/src/Futurice/App/Checklist/Types.hs
+++ b/checklist-app/src/Futurice/App/Checklist/Types.hs
@@ -88,6 +88,7 @@ module Futurice.App.Checklist.Types (
     worldTaskItems',
     worldTasksSorted,
     worldTasksSortedByName,
+    tasksSorted,
     -- * Access
     AuthUser,
     authUserTaskRole,

--- a/checklist-app/src/Futurice/App/Checklist/Types.hs
+++ b/checklist-app/src/Futurice/App/Checklist/Types.hs
@@ -88,7 +88,6 @@ module Futurice.App.Checklist.Types (
     worldTaskItems',
     worldTasksSorted,
     worldTasksSortedByName,
-    worldTasksSortedByOffset,
     -- * Access
     AuthUser,
     authUserTaskRole,

--- a/checklist-app/src/Futurice/App/Checklist/Types.hs
+++ b/checklist-app/src/Futurice/App/Checklist/Types.hs
@@ -88,6 +88,7 @@ module Futurice.App.Checklist.Types (
     worldTaskItems',
     worldTasksSorted,
     worldTasksSortedByName,
+    worldTasksSortedByOffset,
     -- * Access
     AuthUser,
     authUserTaskRole,

--- a/checklist-app/src/Futurice/App/Checklist/Types/World.hs
+++ b/checklist-app/src/Futurice/App/Checklist/Types/World.hs
@@ -15,6 +15,7 @@ module Futurice.App.Checklist.Types.World (
     worldTaskItems',
     worldTasksSorted,
     worldTasksSortedByName,
+    tasksSorted,
     -- * Counters
     toTodoCounter,
     taskItemtoTodoCounter,
@@ -26,7 +27,7 @@ module Futurice.App.Checklist.Types.World (
     ) where
 
 -- import Futurice.Generics
-import Control.Lens     (contains, filtered, (<&>))
+import Control.Lens     (contains, filtered, minimumOf)
 import Data.Functor.Rep (Representable (..))
 import Futurice.Graph   (Graph)
 import Futurice.IdMap   (IdMap)
@@ -34,10 +35,11 @@ import Futurice.Office
 import Futurice.Prelude
 import Prelude ()
 
-import qualified Data.Set       as Set
-import qualified Data.Set.Lens  as Set
-import qualified Futurice.Graph as Graph
-import qualified Futurice.IdMap as IdMap
+import qualified Data.Map.Strict as Map
+import qualified Data.Set        as Set
+import qualified Data.Set.Lens   as Set
+import qualified Futurice.Graph  as Graph
+import qualified Futurice.IdMap  as IdMap
 
 import Futurice.App.Checklist.Types.Basic
 import Futurice.App.Checklist.Types.ChecklistId
@@ -77,26 +79,28 @@ data World = World
     -- lazy fields, updated on need when accessed
     , _worldTaskItems' :: Map (Identifier Task) (Map (Identifier Employee) AnnTaskItem)
       -- ^ isomorphic with 'worldTaskItems'
+    , _worldTasksOrder  :: Map (Identifier Task) Int
+      -- ^ task order changes rarely, so let's cache it.
     }
 
 worldEmployees :: Lens' World (IdMap Employee)
-worldEmployees f (World es ts ls is arc _) = f es <&>
+worldEmployees f (World es ts ls is arc _ _) = f es <&>
     \x -> mkWorld x (Graph.toIdMap ts) ls is arc
 
 worldTasks :: Lens' World (Graph Task)
-worldTasks f (World es ts ls is arc _) = f ts <&>
+worldTasks f (World es ts ls is arc _ _) = f ts <&>
     \x -> mkWorld es (Graph.toIdMap x) ls is arc
 
 worldLists :: Lens' World (PerChecklist Checklist)
-worldLists f (World es ts ls is arc _) = f ls <&>
+worldLists f (World es ts ls is arc _ _) = f ls <&>
     \x -> mkWorld es (Graph.toIdMap ts) x is arc
 
 worldTaskItems :: Lens' World (Map (Identifier Employee) (Map (Identifier Task) AnnTaskItem))
-worldTaskItems f (World es ts ls is arc _) = f is <&>
+worldTaskItems f (World es ts ls is arc _ _) = f is <&>
     \x -> mkWorld es (Graph.toIdMap ts) ls x arc
 
 worldArchive :: Lens' World Archive
-worldArchive f (World es ts ls is arc _) = f arc <&>
+worldArchive f (World es ts ls is arc _ _) = f arc <&>
     \x -> mkWorld es (Graph.toIdMap ts) ls is x
 
 worldTaskItems' :: Getter World (Map (Identifier Task) (Map (Identifier Employee) AnnTaskItem))
@@ -105,21 +109,30 @@ worldTaskItems' = getter _worldTaskItems'
 worldTasksSorted :: TaskRole -> Getter World [Task]
 worldTasksSorted tr = getter $ \world ->
     sortOn ((tr /=) . view taskRole) $
-    map snd $
-    sortOn fst $
-    addWeightToTasks world $
-    Graph.revTopSort (world ^. worldTasks)
-  where
-    neighbourMinWeight :: World -> Task -> Integer
-    neighbourMinWeight w t = fromMaybe (t ^. taskOffset) $
-        foldr min (t ^. taskOffset) <$>
-        map (\x -> x ^. taskOffset) <$>
-        Graph.revClosure (w ^. worldTasks) [(t ^. identifier)]
-    addWeightToTasks :: World -> [Task] -> [(Integer,Task)]
-    addWeightToTasks w = map (\t -> (neighbourMinWeight w t,t))
+    view (tasksSorted world) $
+    world ^.. worldTasks . folded
 
 worldTasksSortedByName :: Getter World [Task]
 worldTasksSortedByName = getter $ \world -> sortOn (view taskName) (world ^.. worldTasks . folded)
+
+tasksSorted :: World -> Getter [Task] [Task]
+tasksSorted world = getter $ sortOn metric where
+    metric :: Task -> Maybe Int
+    metric t = _worldTasksOrder world ^? ix (t ^. identifier)
+
+orderLookup :: Graph Task -> Map (Identifier Task) Int
+orderLookup tasks
+    = Map.fromList
+    $ flip zip [0 ..]
+    $ map fst
+    $ sortOn snd
+    $ map (\t -> (t ^. identifier, closureMinWeight t))
+    $ Graph.revTopSort tasks
+  where
+    closureMinWeight :: Task -> Integer
+    closureMinWeight t = fromMaybe (t ^. taskOffset) $ minimumOf
+        (_Just . folded . taskOffset)
+        (Graph.revClosure tasks [t ^. identifier])
 
 emptyWorld :: World
 emptyWorld = mkWorld mempty mempty emptyChecklists mempty mempty where
@@ -158,6 +171,8 @@ mkWorld es ts ls is arc =
             & IdMap.unsafeTraversal . taskPrereqs
             %~ Set.setOf (folded . filtered validTid)
 
+        tsG = Graph.fromIdMap ts'
+
         ls' = ls
             & traverse . checklistTasks
             %~ Set.filter validTid
@@ -165,7 +180,7 @@ mkWorld es ts ls is arc =
         -- TODO: validate is
 
         swappedIs = swapMapMap is
-    in World es' (Graph.fromIdMap ts') ls' is arc swappedIs
+    in World es' tsG ls' is arc swappedIs (orderLookup tsG)
 
 {-
 

--- a/checklist-app/src/Futurice/App/Checklist/Types/World.hs
+++ b/checklist-app/src/Futurice/App/Checklist/Types/World.hs
@@ -15,6 +15,7 @@ module Futurice.App.Checklist.Types.World (
     worldTaskItems',
     worldTasksSorted,
     worldTasksSortedByName,
+    worldTasksSortedByOffset,
     -- * Counters
     toTodoCounter,
     taskItemtoTodoCounter,
@@ -34,10 +35,12 @@ import Futurice.Office
 import Futurice.Prelude
 import Prelude ()
 
-import qualified Data.Set       as Set
-import qualified Data.Set.Lens  as Set
-import qualified Futurice.Graph as Graph
-import qualified Futurice.IdMap as IdMap
+import qualified Control.Monad.State.Strict as State
+import qualified Data.Map                   as Map
+import qualified Data.Set                   as Set
+import qualified Data.Set.Lens              as Set
+import qualified Futurice.Graph             as Graph
+import qualified Futurice.IdMap             as IdMap
 
 import Futurice.App.Checklist.Types.Basic
 import Futurice.App.Checklist.Types.ChecklistId
@@ -107,6 +110,42 @@ worldTasksSorted tr = getter $ \world ->
     sortOn ((tr /=) . view taskRole) $
     sortOn (view taskOffset) $
     Graph.revTopSort (world ^. worldTasks)
+
+type WeightState = State.State (Map (Identifier Task) Integer)
+
+fetchWeight :: Task -> WeightState Integer
+fetchWeight task = do
+    weightMap <- State.get
+    let weight = fromMaybe (task ^. taskOffset) (weightMap ^.at (task ^. identifier))
+    pure weight
+
+updateWeight :: Task -> Integer -> WeightState ()
+updateWeight task weight = State.modify (Map.insert (task ^. identifier) weight)
+
+neighbourWeights :: Graph Task -> Task -> Maybe (WeightState [Integer])
+neighbourWeights g t = traverse fetchWeight <$> Graph.revNeighbors g (t ^. identifier)
+
+neighbourMinWeight :: Graph Task -> Task -> WeightState Integer
+neighbourMinWeight g t = fromMaybe (pure (t ^. taskOffset)) $
+    (fmap . fmap) (foldr min (t ^. taskOffset)) $ neighbourWeights g t
+
+fetchAndUpdateMinWeight :: Graph Task -> Task -> WeightState (Integer, Task)
+fetchAndUpdateMinWeight g t = do
+    minWeight <- neighbourMinWeight g t
+    updateWeight t minWeight
+    return (minWeight, t)
+
+worldTasksSortedByOffset :: TaskRole -> Getter World [Task]
+worldTasksSortedByOffset tr = getter $ \world ->
+    sortOn ((tr /=) . view taskRole) $
+    map snd $
+    sortOn fst $
+    reverse $
+    flip State.evalState mempty $
+    sortedTasksWithWeight world $
+    Graph.topSort (world ^. worldTasks)
+  where
+    sortedTasksWithWeight world = mapM (fetchAndUpdateMinWeight (world ^. worldTasks))
 
 worldTasksSortedByName :: Getter World [Task]
 worldTasksSortedByName = getter $ \world -> sortOn (view taskName) (world ^.. worldTasks . folded)


### PR DESCRIPTION
Task sorts by:
- First order by dependency
- Then weight each vertex by minimum offset of all of it's "child's"
- Then reorder list based on those weight

A somewhat imperative solution, but seems to work ^^'