### PR TITLE
Add new endpoint for deleting multiple timereports at once

### DIFF
--- a/hours-api/src/Futurice/App/HoursApi.hs
+++ b/hours-api/src/Futurice/App/HoursApi.hs
@@ -24,8 +24,8 @@ import Futurice.App.HoursApi.API
 import Futurice.App.HoursApi.Config
 import Futurice.App.HoursApi.Ctx
 import Futurice.App.HoursApi.Logic
-       (entryDeleteEndpoint, entryEditEndpoint, entryEndpoint, hoursEndpoint,
-       projectEndpoint, userEndpoint)
+       (entryDeleteEndpoint, entryDeleteMultipleEndpoint, entryEditEndpoint,
+       entryEndpoint, hoursEndpoint, projectEndpoint, userEndpoint)
 import Futurice.App.HoursApi.Monad  (Hours, runHours)
 
 import qualified Data.HashMap.Strict as HM
@@ -49,6 +49,7 @@ v1Server ctx =
     :<|> (\mfum eu     -> authorisedUser ctx mfum "entry"   (entryEndpoint eu))
     :<|> (\mfum eid eu -> authorisedUser ctx mfum "edit"    (entryEditEndpoint eid eu))
     :<|> (\mfum eid    -> authorisedUser ctx mfum "delete"  (entryDeleteEndpoint eid))
+    :<|> (\mfum eids   -> authorisedUser ctx mfum "deleteMultiple" (entryDeleteMultipleEndpoint eids))
 
 authorisedUser
     :: Ctx

--- a/hours-api/src/Futurice/App/HoursApi/API.hs
+++ b/hours-api/src/Futurice/App/HoursApi/API.hs
@@ -29,6 +29,7 @@ type FutuhoursV1API =
     :<|> "entry" :> SSOUser :> ReqBody '[JSON] EntryUpdate :> Post '[JSON] EntryUpdateResponse
     :<|> "entry" :> SSOUser :> Capture "id" PM.TimereportId :> ReqBody '[JSON] EntryUpdate :> Put '[JSON] EntryUpdateResponse
     :<|> "entry" :> SSOUser :> Capture "id" PM.TimereportId :> Delete '[JSON] EntryUpdateResponse
+    :<|> "delete-timereports" :> SSOUser :> ReqBody '[JSON] TimereportDelete :> Post '[JSON] EntryUpdateResponse
 
 type FutuhoursAPI = Get '[JSON] Text
     :<|> "api" :> "v1" :> FutuhoursV1API

--- a/hours-api/src/Futurice/App/HoursApi/API.hs
+++ b/hours-api/src/Futurice/App/HoursApi/API.hs
@@ -29,7 +29,7 @@ type FutuhoursV1API =
     :<|> "entry" :> SSOUser :> ReqBody '[JSON] EntryUpdate :> Post '[JSON] EntryUpdateResponse
     :<|> "entry" :> SSOUser :> Capture "id" PM.TimereportId :> ReqBody '[JSON] EntryUpdate :> Put '[JSON] EntryUpdateResponse
     :<|> "entry" :> SSOUser :> Capture "id" PM.TimereportId :> Delete '[JSON] EntryUpdateResponse
-    :<|> "delete-timereports" :> SSOUser :> ReqBody '[JSON] TimereportDelete :> Post '[JSON] EntryUpdateResponse
+    :<|> "delete-timereports" :> SSOUser :> ReqBody '[JSON] [PM.TimereportId] :> Post '[JSON] EntryUpdateResponse
 
 type FutuhoursAPI = Get '[JSON] Text
     :<|> "api" :> "v1" :> FutuhoursV1API

--- a/hours-api/src/Futurice/App/HoursApi/Logic.hs
+++ b/hours-api/src/Futurice/App/HoursApi/Logic.hs
@@ -12,6 +12,7 @@ module Futurice.App.HoursApi.Logic (
     entryEndpoint,
     entryEditEndpoint,
     entryDeleteEndpoint,
+    entryDeleteMultipleEndpoint,
     ) where
 
 import Control.Lens              (maximumOf, (<&>))
@@ -93,6 +94,19 @@ entryDeleteEndpoint eid = do
     tr <- H.timereport eid
     _ <- H.deleteTimereport eid
     entryUpdateResponse (tr ^. H.timereportDay)
+
+-- | POST /delete-timereports@
+entryDeleteMultipleEndpoint :: H.MonadHours m => TimereportDelete -> m EntryUpdateResponse
+entryDeleteMultipleEndpoint (TimereportDelete eids _) = do
+    let deleteTimereport eid = do
+            tr <- H.timereport eid
+            _ <- H.deleteTimereport eid
+            pure tr
+        days = sort . map (^. H.timereportDay)
+        firstDay = head . days
+        lastDay = last . days
+    trs <- mapM deleteTimereport eids
+    EntryUpdateResponse <$> userResponse <*> hoursResponse (firstDay trs ... lastDay trs)
 
 -------------------------------------------------------------------------------
 -- Logic

--- a/hours-api/src/Futurice/App/HoursApi/Types.hs
+++ b/hours-api/src/Futurice/App/HoursApi/Types.hs
@@ -106,13 +106,6 @@ data LatestEntry = LatestEntry
     }
   deriving (Eq, Show, Typeable, Generic)
 
--- | Data type that contains id's of Timereports that should be deleted
-data TimereportDelete = TimereportDelete
-    { _toBeDeleted :: ![PM.TimereportId]
-    , _notUsed :: !(Maybe Text) --TODO: Why is this padding needed?
-    }
-  deriving (Eq, Show, Typeable, Generic)
-
 -- | When frontend sends closed entry to be updated, API doesn't do anything, just respond ok
 --
 -- /TODO:/ is this *new* entry, probably we don't need closed field at all?
@@ -200,9 +193,6 @@ deriveGeneric ''MarkedTask
 
 makeLenses ''LatestEntry
 deriveGeneric ''LatestEntry
-
-makeLenses ''TimereportDelete
-deriveGeneric ''TimereportDelete
 
 makeLenses ''Entry
 deriveGeneric ''Entry
@@ -341,11 +331,6 @@ deriveVia [t| Arbitrary LatestEntry `Via` Sopica LatestEntry |]
 deriveVia [t| ToJSON LatestEntry    `Via` Sopica LatestEntry |]
 deriveVia [t| FromJSON LatestEntry  `Via` Sopica LatestEntry |]
 instance ToSchema LatestEntry where declareNamedSchema = sopDeclareNamedSchema
-
-deriveVia [t| Arbitrary TimereportDelete `Via` Sopica TimereportDelete |]
-deriveVia [t| ToJSON TimereportDelete    `Via` Sopica TimereportDelete |]
-deriveVia [t| FromJSON TimereportDelete  `Via` Sopica TimereportDelete |]
-instance ToSchema TimereportDelete where declareNamedSchema = sopDeclareNamedSchema
 
 deriveVia [t| Arbitrary Entry `Via` Sopica Entry |]
 deriveVia [t| ToJSON Entry    `Via` Sopica Entry |]

--- a/hours-api/src/Futurice/App/HoursApi/Types.hs
+++ b/hours-api/src/Futurice/App/HoursApi/Types.hs
@@ -26,10 +26,10 @@ import Numeric.Interval.NonEmpty (Interval, inf, sup, (...))
 import Prelude ()
 import Test.QuickCheck           (arbitraryBoundedEnum)
 
-import qualified Data.Map        as Map
-import qualified PlanMill        as PM
-import qualified Test.QuickCheck as QC
+import qualified Data.Map                  as Map
 import qualified Numeric.Interval.NonEmpty as Interval
+import qualified PlanMill                  as PM
+import qualified Test.QuickCheck           as QC
 
 -------------------------------------------------------------------------------
 -- Project
@@ -103,6 +103,13 @@ data LatestEntry = LatestEntry
     { _latestEntryDescription :: !Text
     , _latestEntryDate        :: !Day
     , _latestEntryHours       :: !(NDT 'Hours Centi)
+    }
+  deriving (Eq, Show, Typeable, Generic)
+
+-- | Data type that contains id's of Timereports that should be deleted
+data TimereportDelete = TimereportDelete
+    { _toBeDeleted :: ![PM.TimereportId]
+    , _notUsed :: !(Maybe Text) --TODO: Why is this padding needed?
     }
   deriving (Eq, Show, Typeable, Generic)
 
@@ -193,6 +200,9 @@ deriveGeneric ''MarkedTask
 
 makeLenses ''LatestEntry
 deriveGeneric ''LatestEntry
+
+makeLenses ''TimereportDelete
+deriveGeneric ''TimereportDelete
 
 makeLenses ''Entry
 deriveGeneric ''Entry
@@ -331,6 +341,11 @@ deriveVia [t| Arbitrary LatestEntry `Via` Sopica LatestEntry |]
 deriveVia [t| ToJSON LatestEntry    `Via` Sopica LatestEntry |]
 deriveVia [t| FromJSON LatestEntry  `Via` Sopica LatestEntry |]
 instance ToSchema LatestEntry where declareNamedSchema = sopDeclareNamedSchema
+
+deriveVia [t| Arbitrary TimereportDelete `Via` Sopica TimereportDelete |]
+deriveVia [t| ToJSON TimereportDelete    `Via` Sopica TimereportDelete |]
+deriveVia [t| FromJSON TimereportDelete  `Via` Sopica TimereportDelete |]
+instance ToSchema TimereportDelete where declareNamedSchema = sopDeclareNamedSchema
 
 deriveVia [t| Arbitrary Entry `Via` Sopica Entry |]
 deriveVia [t| ToJSON Entry    `Via` Sopica Entry |]

--- a/hours-api/src/Futurice/App/HoursMock.hs
+++ b/hours-api/src/Futurice/App/HoursMock.hs
@@ -8,9 +8,9 @@
 {-# LANGUAGE TypeOperators         #-}
 module Futurice.App.HoursMock (defaultMain) where
 
-import Prelude ()
 import Futurice.Prelude
 import Futurice.Servant
+import Prelude ()
 import Servant
 
 import Futurice.App.HoursApi.API
@@ -33,6 +33,7 @@ v1Server ctx =
     :<|> (\_ eu     -> runHours ctx (entryEndpoint eu))
     :<|> (\_ eid eu -> runHours ctx (entryEditEndpoint eid eu))
     :<|> (\_ eid    -> runHours ctx (entryDeleteEndpoint eid))
+    :<|> (\_ eids    -> runHours ctx (entryDeleteMultipleEndpoint eids))
 
 defaultMain :: IO ()
 defaultMain = futuriceServerMain (const makeCtx) $ emptyServerConfig


### PR DESCRIPTION
TimereportDelete type needed extra data type to get ToJson and FromJson to work. Why is that and can it be fixed some other way? I think there was similar problem previously, but can't remember where