### PR TITLE
Reformat all .cabal files

### DIFF
--- a/arcola/arcola.cabal
+++ b/arcola/arcola.cabal
@@ -1,32 +1,33 @@
-name:                arcola
-version:             0
-synopsis:            A barebone network servers
-description:         Arcola is sublabel of warp. Let's you write simple, non-HTTP servers.
-homepage:            https://github.com/futurice/haskell-mega-repo
-license:             BSD3
-license-file:        LICENSE
-author:              Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:          Oleg Grenrus <oleg.grenrus@iki.fi>
-copyright:           (c) 2017 Futurice
-category:            Network
-build-type:          Simple
-cabal-version:       >=1.10
+cabal-version: 2.2
+name:          arcola
+version:       0
+synopsis:      A barebone network servers
+description:
+  Arcola is sublabel of warp. Let's you write simple, non-HTTP servers.
+homepage:      https://github.com/futurice/haskell-mega-repo
+license:       BSD-3-Clause
+license-file:  LICENSE
+author:        Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:    Oleg Grenrus <oleg.grenrus@iki.fi>
+copyright:     (c) 2017 Futurice
+category:      Network
+build-type:    Simple
 
 library
-  default-language:    Haskell2010
-  hs-source-dirs:      src
-  exposed-modules:     Network.Arcola
+  default-language: Haskell2010
+  hs-source-dirs:   src
+  exposed-modules:  Network.Arcola
   build-depends:
-    base >=4.9 && <4.13,
-    bytestring,
-    streaming-commons,
-    network
+    , base
+    , bytestring
+    , network
+    , streaming-commons
 
 executable arcola-echo
-  default-language:    Haskell2010
-  hs-source-dirs:      echo
-  main-is:             Main.hs
+  default-language: Haskell2010
+  hs-source-dirs:   echo
+  main-is:          Main.hs
   build-depends:
-    base,
-    bytestring,
-    arcola
+    , arcola
+    , base
+    , bytestring

--- a/avatar-app/avatar-app.cabal
+++ b/avatar-app/avatar-app.cabal
@@ -1,29 +1,25 @@
-cabal-version:  2.2
-name:           avatar-app
-version:        0
-
-synopsis:       Avatar app
-description:    Make an avatar of everything
-category:       Web
-homepage:       https://github.com/futurice/avatar-app#readme
-bug-reports:    https://github.com/futurice/avatar-app/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD-3-Clause
-license-file:   LICENSE
-build-type:     Simple
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               avatar-app
+version:            0
+synopsis:           Avatar app
+description:        Make an avatar of everything
+category:           Web
+homepage:           https://github.com/futurice/avatar-app#readme
+bug-reports:        https://github.com/futurice/avatar-app/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/avatar-app
 
 library
-  hs-source-dirs:
-      src
-  ghc-options: -Wall
+  hs-source-dirs:     src
+  ghc-options:        -Wall
   default-extensions:
     DeriveDataTypeable
     DeriveFoldable
@@ -32,13 +28,13 @@ library
     DeriveTraversable
     ScopedTypeVariables
   build-depends:
-    , base
     , aeson-compat
     , amazonka
     , amazonka-lambda
     , amazonka-s3
     , avatar-client
     , avatar-internal
+    , base
     , base-compat
     , blaze-html
     , bytestring
@@ -48,8 +44,8 @@ library
     , file-embed
     , fum-client
     , fum-types
-    , futurice-integrations
     , futurice-foundation
+    , futurice-integrations
     , futurice-prelude
     , futurice-servant
     , http-client
@@ -71,29 +67,27 @@ library
     , unordered-containers
     , vector
   exposed-modules:
-      Futurice.App.Avatar
-      Futurice.App.Avatar.Config
-      Futurice.App.Avatar.Ctx
-      Futurice.App.Avatar.Embedded
-      Futurice.App.Avatar.Markup
-  default-language: Haskell2010
+    Futurice.App.Avatar
+    Futurice.App.Avatar.Config
+    Futurice.App.Avatar.Ctx
+    Futurice.App.Avatar.Embedded
+    Futurice.App.Avatar.Markup
+  default-language:   Haskell2010
 
 executable avatar-server
-  main-is: Main.hs
-  hs-source-dirs:
-      srv
-  ghc-options: -Wall -threaded -rtsopts
+  main-is:          Main.hs
+  hs-source-dirs:   srv
+  ghc-options:      -Wall -threaded -rtsopts
   build-depends:
-      base
     , avatar-app
+    , base
   default-language: Haskell2010
 
 library avatar-internal
   default-language: Haskell2010
   ghc-options:      -Wall
   hs-source-dirs:   src-internal
-  exposed-modules:
-      Futurice.App.Avatar.Types
+  exposed-modules:  Futurice.App.Avatar.Types
   build-depends:
     , base
     , base64-bytestring
@@ -106,23 +100,19 @@ executable avatar-process-lambda
   hs-source-dirs:   src-process lambdas
   main-is:          ProcessLambda.hs
   default-language: Haskell2010
-  other-modules:
-    Futurice.Lambda.Avatar.Process
-
+  other-modules:    Futurice.Lambda.Avatar.Process
   build-depends:
-    , base
     , amazonka
     , amazonka-s3
     , avatar-internal
+    , base
     , bytestring
     , env-config
     , futurice-lambda
     , futurice-prelude
     , http-client
-    , JuicyPixels >=3.2.7
-    , JuicyPixels-scale-dct >=0.1.0.0
+    , JuicyPixels            >=3.2.7
+    , JuicyPixels-scale-dct  >=0.1.0.0
     , linear
     , vector
-
-  build-depends:
-    , aeson
+  build-depends:    aeson

--- a/avatar-client/avatar-client.cabal
+++ b/avatar-client/avatar-client.cabal
@@ -1,35 +1,33 @@
-name:           avatar-client
-version:        0
-synopsis:       Avatar client
-description:    Avatar client
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.10.3, GHC==8.0.2
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               avatar-client
+version:            0
+synopsis:           Avatar client
+description:        Avatar client
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
+  exposed-modules:    Futurice.App.Avatar.API
   default-extensions:
     DerivingStrategies
     GeneralizedNewtypeDeriving
-  ghc-options: -Wall
   build-depends:
-      base                  >=4.7   && <4.13
     , aeson
+    , base
     , bytestring
     , fum-types
     , futurice-prelude
@@ -38,6 +36,3 @@ library
     , servant-cached
     , servant-JuicyPixels
     , swagger2
-  exposed-modules:
-      Futurice.App.Avatar.API
-  default-language: Haskell2010

--- a/badge-app/badge-app.cabal
+++ b/badge-app/badge-app.cabal
@@ -1,78 +1,82 @@
-name:           badge-app
-version:        0
-synopsis:       Generate badges
-description:    Genreate badges
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-build-type:     Simple
-cabal-version:  >= 1.10
+cabal-version: 2.2
+name:          badge-app
+version:       0
+synopsis:      Generate badges
+description:   Genreate badges
+category:      Web
+homepage:      https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:   https://github.com/futurice/haskell-mega-repo/issues
+author:        Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:    Oleg Grenrus <oleg.grenrus@iki.fi>
+license:       BSD-3-Clause
+license-file:  LICENSE
+build-type:    Simple
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
+  default-extensions:
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ScopedTypeVariables
   build-depends:
-      base >= 4.9 && <4.13,
-      avatar-client,
-      bytestring,
-      containers,
-      diagrams-lib,
-      diagrams-rasterific,
-      diagrams-svg,
-      env-config,
-      exceptions,
-      file-embed-lzma,
-      filepath,
-      fum-types,
-      futurice-constants,
-      futurice-foundation,
-      futurice-integrations,
-      futurice-prelude,
-      futurice-servant,
-      futurice-tribes,
-      JuicyPixels,
-      JuicyPixels-extra,
-      lens,
-      mtl,
-      personio-client,
-      servant,
-      servant-cached,
-      servant-client,
-      servant-client-core,
-      servant-JuicyPixels,
-      servant-server,
-      SVGFonts,
-      tar,
-      template-haskell,
-      text
- 
+    , avatar-client
+    , base
+    , bytestring
+    , containers
+    , diagrams-lib
+    , diagrams-rasterific
+    , diagrams-svg
+    , env-config
+    , exceptions
+    , file-embed-lzma
+    , filepath
+    , fum-types
+    , futurice-constants
+    , futurice-foundation
+    , futurice-integrations
+    , futurice-prelude
+    , futurice-servant
+    , futurice-tribes
+    , JuicyPixels
+    , JuicyPixels-extra
+    , lens
+    , mtl
+    , personio-client
+    , servant
+    , servant-cached
+    , servant-client
+    , servant-client-core
+    , servant-JuicyPixels
+    , servant-server
+    , SVGFonts
+    , tar
+    , template-haskell
+    , text
   exposed-modules:
-      Futurice.App.Badge.API
-      Futurice.App.Badge.Config
-      Futurice.App.Badge.Ctx
-      Futurice.App.Badge.Data
-      Futurice.App.Badge.IndexPage
-      Futurice.App.Badge.Main
-      Futurice.App.Badge.Markup
-      Futurice.App.Badge.Templates
-      Futurice.App.Badge.Tools
-
-  default-language: Haskell2010
+    Futurice.App.Badge.API
+    Futurice.App.Badge.Config
+    Futurice.App.Badge.Ctx
+    Futurice.App.Badge.Data
+    Futurice.App.Badge.IndexPage
+    Futurice.App.Badge.Main
+    Futurice.App.Badge.Markup
+    Futurice.App.Badge.Templates
+    Futurice.App.Badge.Tools
 
 executable badge-app-server
-  main-is: Main.hs
-  hs-source-dirs:
-      srv
-  ghc-options: -Wall -Wall -threaded -rtsopts
-  build-depends: base, badge-app
   default-language: Haskell2010
+  main-is:          Main.hs
+  hs-source-dirs:   srv
+  ghc-options:      -Wall -Wall -threaded -rtsopts
+  build-depends:
+    , badge-app
+    , base

--- a/checklist-app/checklist-app.cabal
+++ b/checklist-app/checklist-app.cabal
@@ -1,27 +1,26 @@
-name:           checklist-app
-version:        0
-synopsis:       Over-engineered TODO
-description:    ...
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-build-type:     Simple
-cabal-version:  >= 1.10
+cabal-version: 2.2
+name:          checklist-app
+version:       0
+synopsis:      Over-engineered TODO
+description:   ...
+category:      Web
+homepage:      https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:   https://github.com/futurice/haskell-mega-repo/issues
+author:        Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:    Oleg Grenrus <oleg.grenrus@iki.fi>
+license:       BSD-3-Clause
+license-file:  LICENSE
+build-type:    Simple
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  default-language: Haskell2010
-  hs-source-dirs: src
-  ghc-options: -Wall
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
   default-extensions:
-    GeneralizedNewtypeDeriving
     DeriveAnyClass
     DeriveDataTypeable
     DeriveFoldable
@@ -29,9 +28,9 @@ library
     DeriveGeneric
     DeriveTraversable
     DerivingStrategies
+    GeneralizedNewtypeDeriving
     ScopedTypeVariables
   build-depends:
-      base >= 4.7 && <4.13
     , adjunctions
     , aeson
     , aeson-compat
@@ -39,6 +38,7 @@ library
     , ansi-pretty
     , ansi-wl-pprint
     , async
+    , base
     , base64-bytestring
     , cassava
     , Chart
@@ -46,9 +46,9 @@ library
     , constraints
     , containers
     , crypto-api
-    , DRBG
     , deepseq
     , distributive
+    , DRBG
     , env-config
     , flowdock-rest
     , fum-api
@@ -64,7 +64,7 @@ library
     , generics-sop-lens
     , github
     , http-api-data
-    , lattices >=1.6
+    , lattices                  >=1.6
     , lens
     , lens-aeson
     , lucid
@@ -74,7 +74,7 @@ library
     , planmill-client
     , postgresql-simple
     , QuickCheck
-    , recursion-schemes >= 5.0.1
+    , recursion-schemes         >=5.0.1
     , reflection
     , regex-applicative
     , resource-pool
@@ -92,71 +92,72 @@ library
     , trifecta
     , uuid
   exposed-modules:
-      Futurice.App.Checklist
-      Futurice.App.Checklist.Ack
-      Futurice.App.Checklist.API
-      Futurice.App.Checklist.Charts.Done
-      Futurice.App.Checklist.Clay
-      Futurice.App.Checklist.Command
-      Futurice.App.Checklist.Config
-      Futurice.App.Checklist.Ctx
-      Futurice.App.Checklist.Logic
-      Futurice.App.Checklist.Markup
-      Futurice.App.Checklist.Pages.Agents
-      Futurice.App.Checklist.Pages.AgentAudit
-      Futurice.App.Checklist.Pages.Archive
-      Futurice.App.Checklist.Pages.Checklist
-      Futurice.App.Checklist.Pages.Checklists
-      Futurice.App.Checklist.Pages.CreateEmployee
-      Futurice.App.Checklist.Pages.CreateTask
-      Futurice.App.Checklist.Pages.Employee
-      Futurice.App.Checklist.Pages.EmployeeAudit
-      Futurice.App.Checklist.Pages.Error
-      Futurice.App.Checklist.Pages.HelpAppliance
-      Futurice.App.Checklist.Pages.HelpServices
-      Futurice.App.Checklist.Pages.Index
-      Futurice.App.Checklist.Pages.More
-      Futurice.App.Checklist.Pages.Personio
-      Futurice.App.Checklist.Pages.Report
-      Futurice.App.Checklist.Pages.Stats
-      Futurice.App.Checklist.Pages.Task
-      Futurice.App.Checklist.Pages.Tasks
-      Futurice.App.Checklist.Personio
-      Futurice.App.Checklist.Types
-      Futurice.App.Checklist.Types.Basic
-      Futurice.App.Checklist.Types.ChecklistId
-      Futurice.App.Checklist.Types.ContractType
-      Futurice.App.Checklist.Types.Counter
-      Futurice.App.Checklist.Types.Identifier
-      Futurice.App.Checklist.Types.SortCriteria
-      Futurice.App.Checklist.Types.TaskAppliance
-      Futurice.App.Checklist.Types.TaskComment
-      Futurice.App.Checklist.Types.TaskItem
-      Futurice.App.Checklist.Types.TaskRole
-      Futurice.App.Checklist.Types.TaskTag
-      Futurice.App.Checklist.Types.World
+    Futurice.App.Checklist
+    Futurice.App.Checklist.API
+    Futurice.App.Checklist.Ack
+    Futurice.App.Checklist.Charts.Done
+    Futurice.App.Checklist.Clay
+    Futurice.App.Checklist.Command
+    Futurice.App.Checklist.Config
+    Futurice.App.Checklist.Ctx
+    Futurice.App.Checklist.Logic
+    Futurice.App.Checklist.Markup
+    Futurice.App.Checklist.Pages.AgentAudit
+    Futurice.App.Checklist.Pages.Agents
+    Futurice.App.Checklist.Pages.Archive
+    Futurice.App.Checklist.Pages.Checklist
+    Futurice.App.Checklist.Pages.Checklists
+    Futurice.App.Checklist.Pages.CreateEmployee
+    Futurice.App.Checklist.Pages.CreateTask
+    Futurice.App.Checklist.Pages.Employee
+    Futurice.App.Checklist.Pages.EmployeeAudit
+    Futurice.App.Checklist.Pages.Error
+    Futurice.App.Checklist.Pages.HelpAppliance
+    Futurice.App.Checklist.Pages.HelpServices
+    Futurice.App.Checklist.Pages.Index
+    Futurice.App.Checklist.Pages.More
+    Futurice.App.Checklist.Pages.Personio
+    Futurice.App.Checklist.Pages.Report
+    Futurice.App.Checklist.Pages.Stats
+    Futurice.App.Checklist.Pages.Task
+    Futurice.App.Checklist.Pages.Tasks
+    Futurice.App.Checklist.Personio
+    Futurice.App.Checklist.Types
+    Futurice.App.Checklist.Types.Basic
+    Futurice.App.Checklist.Types.ChecklistId
+    Futurice.App.Checklist.Types.ContractType
+    Futurice.App.Checklist.Types.Counter
+    Futurice.App.Checklist.Types.Identifier
+    Futurice.App.Checklist.Types.SortCriteria
+    Futurice.App.Checklist.Types.TaskAppliance
+    Futurice.App.Checklist.Types.TaskComment
+    Futurice.App.Checklist.Types.TaskItem
+    Futurice.App.Checklist.Types.TaskRole
+    Futurice.App.Checklist.Types.TaskTag
+    Futurice.App.Checklist.Types.World
 
 executable checklist-app-server
-  main-is: Main.hs
-  hs-source-dirs:
-      srv
-  ghc-options: -Wall -Wall -threaded -rtsopts
+  main-is:          Main.hs
+  default-language: Haskell2010
+  hs-source-dirs:   srv
+  ghc-options:      -Wall -Wall -threaded -rtsopts
   build-depends:
-      base >= 4.7 && <4.13
     , adjunctions
     , aeson
     , aeson-compat
     , ansi-pretty
     , ansi-wl-pprint
     , async
+    , base
     , Chart
+    , checklist-app
     , clay
     , constraints
     , containers
     , crypto-api
-    , DRBG
     , deepseq
     , distributive
+    , DRBG
     , env-config
     , fum-api
     , fum-types
@@ -169,7 +170,7 @@ executable checklist-app-server
     , generics-sop-lens
     , github
     , http-api-data
-    , lattices >=1.6
+    , lattices               >=1.6
     , lens
     , lens-aeson
     , lucid
@@ -178,7 +179,7 @@ executable checklist-app-server
     , personio-client
     , postgresql-simple
     , QuickCheck
-    , recursion-schemes >= 5.0.1
+    , recursion-schemes      >=5.0.1
     , reflection
     , regex-applicative
     , resource-pool
@@ -194,20 +195,17 @@ executable checklist-app-server
     , time
     , trifecta
     , uuid
-    , checklist-app
-  default-language: Haskell2010
 
 test-suite unit-tests
-  type: exitcode-stdio-1.0
-  main-is: Tests.hs
-  hs-source-dirs:
-      tests/
-  ghc-options: -Wall
+  default-language: Haskell2010
+  type:             exitcode-stdio-1.0
+  main-is:          Tests.hs
+  hs-source-dirs:   tests/
+  ghc-options:      -Wall
   build-depends:
-      base
     , aeson
+    , base
+    , checklist-app
     , futurice-prelude
     , tasty
     , tasty-quickcheck
-    , checklist-app
-  default-language: Haskell2010

--- a/contacts-api/contacts-api.cabal
+++ b/contacts-api/contacts-api.cabal
@@ -1,38 +1,40 @@
-name:           contacts-api
-version:        0
-synopsis:       Contacts api
-description:    New and fancy
-category:       Web
-homepage:       https://github.com/futurice/contacts-api#readme
-bug-reports:    https://github.com/futurice/contacts-api/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.8.4, GHC==7.10.2
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      >=1.10
+name:               contacts-api
+version:            0
+synopsis:           Contacts api
+description:        New and fancy
+category:           Web
+homepage:           https://github.com/futurice/contacts-api#readme
+bug-reports:        https://github.com/futurice/contacts-api/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/contacts-api
 
 library
-  hs-source-dirs:
-      src
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall -freduction-depth=30
   default-extensions:
     DeriveAnyClass
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
     DerivingStrategies
-    DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall
+    ScopedTypeVariables
   build-depends:
-      base                  >=4.7   && <4.13
-    , aeson
+      aeson
     , aeson-compat
     , avatar-client
+    , base
     , base-compat
     , bifunctors
     , binary-orphans
@@ -76,7 +78,7 @@ library
     , servant-server
     , SHA
     , stm
-    , strict-base-types >=0.4
+    , strict-base-types      >=0.4
     , swagger2
     , tagged
     , text
@@ -86,29 +88,25 @@ library
     , unordered-containers
     , vector
     , wai
-  if impl(ghc >= 8.0)
-    ghc-options: -freduction-depth=30
-  else
-    ghc-options: -fcontext-stack=30
   exposed-modules:
-      Futurice.App.Contacts
-      Futurice.App.Contacts.API
-      Futurice.App.Contacts.Config
-      Futurice.App.Contacts.Logic
-      Futurice.App.Contacts.Types
-  default-language: Haskell2010
+    Futurice.App.Contacts
+    Futurice.App.Contacts.API
+    Futurice.App.Contacts.Config
+    Futurice.App.Contacts.Logic
+    Futurice.App.Contacts.Types
 
 executable contacts-api-server
-  main-is: Main.hs
-  hs-source-dirs:
-      srv
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall -threaded -rtsopts
+  default-language:   Haskell2010
+  main-is:            Main.hs
+  ghc-options:        -Wall -threaded -rtsopts -freduction-depth=30
+  hs-source-dirs:     srv
+  default-extensions:
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ScopedTypeVariables
   build-depends:
       base
     , contacts-api
-  if impl(ghc >= 8.0)
-    ghc-options: -freduction-depth=30
-  else
-    ghc-options: -fcontext-stack=30
-  default-language: Haskell2010

--- a/dynmap-cache/dynmap-cache.cabal
+++ b/dynmap-cache/dynmap-cache.cabal
@@ -1,32 +1,29 @@
-name:           dynmap-cache
-version:        0
-synopsis:       Dynamic STM based cache
-description:    Dynamic STM based cache
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==8.0.2, GHC==8.2.1
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               dynmap-cache
+version:            0
+synopsis:           Dynamic STM based cache
+description:        Dynamic STM based cache
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  ghc-options: -Wall
+  default-language: Haskell2010
+  hs-source-dirs:   src
+  ghc-options:      -Wall
   build-depends:
-      base            >=4.9      && <4.13
     , async
+    , base
     , base-compat
     , bytestring
     , deepseq
@@ -48,23 +45,21 @@ library
     , transformers-compat
     , unordered-containers
   exposed-modules:
-      Futurice.Cache
-      Futurice.DynMap
-  default-language: Haskell2010
+    Futurice.Cache
+    Futurice.DynMap
 
 test-suite unit-tests
-  type: exitcode-stdio-1.0
-  main-is: Tests.hs
-  hs-source-dirs:
-      test
-  ghc-options: -Wall -threaded -rtsopts
+  type:             exitcode-stdio-1.0
+  main-is:          Tests.hs
+  hs-source-dirs:   test
+  ghc-options:      -Wall -threaded -rtsopts
   build-depends:
-      base            >=4.9      && <4.13
-    , dynmap-cache
     , async
-    , stm
+    , base
+    , dynmap-cache
     , futurice-prelude
+    , stm
   build-depends:
-      tasty
+    , tasty
     , tasty-hunit
   default-language: Haskell2010

--- a/email-proxy-client/email-proxy-client.cabal
+++ b/email-proxy-client/email-proxy-client.cabal
@@ -1,35 +1,32 @@
-name:           email-proxy-client
-version:        0
-synopsis:       Email Proxy
-description:    Make an email-proxy of everything
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.10.3, GHC==8.0.2
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               email-proxy-client
+version:            0
+synopsis:           Email Proxy
+description:        Make an email-proxy of everything
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
   default-extensions:
     DerivingStrategies
     GeneralizedNewtypeDeriving
-  ghc-options: -Wall
   build-depends:
-      base                  >=4.7   && <4.13
     , aeson
+    , base
     , base-compat
     , bytestring
     , env-config
@@ -43,7 +40,6 @@ library
     , text
     , time
   exposed-modules:
-      Futurice.App.EmailProxy.API
-      Futurice.App.EmailProxy.Client
-      Futurice.App.EmailProxy.Types
-  default-language: Haskell2010
+    Futurice.App.EmailProxy.API
+    Futurice.App.EmailProxy.Client
+    Futurice.App.EmailProxy.Types

--- a/email-proxy/email-proxy.cabal
+++ b/email-proxy/email-proxy.cabal
@@ -1,34 +1,31 @@
-name:           email-proxy
-version:        0
-synopsis:       Email Proxy
-description:    Make an email-proxy of everything
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.10.3, GHC==8.0.2
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               email-proxy
+version:            0
+synopsis:           Email Proxy
+description:        Make an email-proxy of everything
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  ghc-options: -Wall
+  default-language: Haskell2010
+  hs-source-dirs:   src
+  ghc-options:      -Wall
   build-depends:
-      base                  >=4.7   && <4.13
     , aeson
     , amazonka
     , amazonka-ses
+    , base
     , base-compat
     , bytestring
     , email-proxy-client
@@ -42,29 +39,26 @@ library
     , text
     , time
   exposed-modules:
-      Futurice.App.EmailProxy.Main
-      Futurice.App.EmailProxy.Mock
-      Futurice.App.EmailProxy.Config
-      Futurice.App.EmailProxy.Ctx
-      Futurice.App.EmailProxy.Logic
-  default-language: Haskell2010
+    Futurice.App.EmailProxy.Config
+    Futurice.App.EmailProxy.Ctx
+    Futurice.App.EmailProxy.Logic
+    Futurice.App.EmailProxy.Main
+    Futurice.App.EmailProxy.Mock
 
 executable email-proxy-server
-  main-is: Main.hs
-  hs-source-dirs:
-      srv
-  ghc-options: -Wall -threaded -rtsopts
-  build-depends:
-      base
-    , email-proxy
   default-language: Haskell2010
+  main-is:          Main.hs
+  hs-source-dirs:   srv
+  ghc-options:      -Wall -threaded -rtsopts
+  build-depends:
+    , base
+    , email-proxy
 
 executable email-proxy-mock
-  main-is: Main.hs
-  hs-source-dirs:
-      mock
-  ghc-options: -Wall -threaded -rtsopts
-  build-depends:
-      base
-    , email-proxy
   default-language: Haskell2010
+  main-is:          Main.hs
+  hs-source-dirs:   mock
+  ghc-options:      -Wall -threaded -rtsopts
+  build-depends:
+    , base
+    , email-proxy

--- a/env-config/env-config.cabal
+++ b/env-config/env-config.cabal
@@ -1,33 +1,37 @@
-name:           env-config
-version:        0
-synopsis:       Parse environment variables
-description:    ...
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.8.4, GHC==7.10.3
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               env-config
+version:            0
+synopsis:           Parse environment variables
+description:        ...
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
+  exposed-modules:    Futurice.EnvConfig
+  default-extensions:
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ScopedTypeVariables
   build-depends:
-      base                  >=4.7   && <4.13
     , amazonka
+    , base    
     , base16-bytestring
     , bytestring
     , containers
@@ -36,7 +40,7 @@ library
     , futurice-prelude
     , github
     , http-client
-    , lattices >=1.5.0
+    , lattices               >=1.5.0
     , monad-logger
     , postgresql-simple
     , postgresql-simple-url
@@ -45,6 +49,3 @@ library
     , split
     , text
     , uuid-types
-  exposed-modules:
-      Futurice.EnvConfig
-  default-language: Haskell2010

--- a/flowdock-proxy/flowdock-proxy.cabal
+++ b/flowdock-proxy/flowdock-proxy.cabal
@@ -1,24 +1,25 @@
-name:           flowdock-proxy
-version:        0
-synopsis:       Flowdock proxy and cache
-description:    flowdock proxy and cache
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-build-type:     Simple
-cabal-version:  >= 1.10
+cabal-version: 2.2
+name:          flowdock-proxy
+version:       0
+synopsis:      Flowdock proxy and cache
+description:   flowdock proxy and cache
+category:      Web
+homepage:      https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:   https://github.com/futurice/haskell-mega-repo/issues
+author:        Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:    Oleg Grenrus <oleg.grenrus@iki.fi>
+license:       BSD-3-Clause
+license-file:  LICENSE
+build-type:    Simple
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
   default-extensions:
     DeriveAnyClass
     DeriveDataTypeable
@@ -29,65 +30,59 @@ library
     DerivingStrategies
     GeneralizedNewtypeDeriving
     ScopedTypeVariables
-  ghc-options: -Wall
   build-depends:
-      aeson,
-      async,
-      base,
-      Chart,
-      clay,
-      cmark-gfm,
-      containers,
-      deepseq,
-      env-config,
-      flowdock-rest,
-      fum-types,
-      futurice-foundation,
-      futurice-integrations,
-      futurice-postgres,
-      futurice-prelude,
-      futurice-servant,
-      futurice-tribes,
-      lens,
-      mtl,
-      periocron,
-      personio-client,
-      postgresql-simple,
-      servant,
-      servant-cached,
-      servant-Chart,
-      servant-server,
-      stm,
-      text,
-      text-short,
-      text-containers,
-      these,
-      time,
-      vector,
-      xss-sanitize
-
-  if impl(ghc >= 8.4.4)
-    build-depends:
-      ghc-compact
-
+    , aeson
+    , async
+    , base
+    , Chart
+    , clay
+    , cmark-gfm
+    , containers
+    , deepseq
+    , env-config
+    , flowdock-rest
+    , fum-types
+    , futurice-foundation
+    , futurice-integrations
+    , futurice-postgres
+    , futurice-prelude
+    , futurice-servant
+    , futurice-tribes
+    , ghc-compact
+    , lens
+    , mtl
+    , periocron
+    , personio-client
+    , postgresql-simple
+    , servant
+    , servant-cached
+    , servant-Chart
+    , servant-server
+    , stm
+    , text
+    , text-containers
+    , text-short
+    , these
+    , time
+    , vector
+    , xss-sanitize
   exposed-modules:
-      Futurice.App.FlowdockProxy.API
-      Futurice.App.FlowdockProxy.Charts
-      Futurice.App.FlowdockProxy.Clay
-      Futurice.App.FlowdockProxy.Config
-      Futurice.App.FlowdockProxy.Ctx
-      Futurice.App.FlowdockProxy.DB
-      Futurice.App.FlowdockProxy.IndexPage
-      Futurice.App.FlowdockProxy.Main
-      Futurice.App.FlowdockProxy.Markup
-      Futurice.App.FlowdockProxy.UsersPage
-
-  default-language: Haskell2010
+    Futurice.App.FlowdockProxy.API
+    Futurice.App.FlowdockProxy.Charts
+    Futurice.App.FlowdockProxy.Clay
+    Futurice.App.FlowdockProxy.Config
+    Futurice.App.FlowdockProxy.Ctx
+    Futurice.App.FlowdockProxy.DB
+    Futurice.App.FlowdockProxy.IndexPage
+    Futurice.App.FlowdockProxy.Main
+    Futurice.App.FlowdockProxy.Markup
+    Futurice.App.FlowdockProxy.UsersPage
 
 executable flowdock-proxy-server
-  main-is: Main.hs
-  hs-source-dirs:
-      srv
-  ghc-options: -Wall -Wall -threaded -rtsopts
-  build-depends: base, flowdock-proxy
   default-language: Haskell2010
+  main-is:          Main.hs
+  hs-source-dirs:   srv
+  ghc-options:      -Wall -Wall -threaded -rtsopts
+  build-depends:
+    , base
+    , flowdock-proxy

--- a/fum-api/fum-api.cabal
+++ b/fum-api/fum-api.cabal
@@ -1,35 +1,39 @@
-name:           fum-api
-version:        0
-synopsis:       FUM API
-description:    FUM-API
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.8.4, GHC==7.10.3, GHC==8.0.1
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               fum-api
+version:            0
+synopsis:           FUM API
+description:        FUM-API
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
+  exposed-modules:    Futurice.FUM.MachineAPI
+  default-extensions:
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ScopedTypeVariables
   build-depends:
-      base >=4.8   && <4.13
     , aeson
     , aeson-compat
     , async
+    , base            
     , binary
     , binary-tagged
     , dependent-sum
@@ -45,6 +49,3 @@ library
     , servant
     , swagger2
     , text
-  exposed-modules:
-      Futurice.FUM.MachineAPI
-  default-language: Haskell2010

--- a/fum-carbon-app/fum-carbon-app.cabal
+++ b/fum-carbon-app/fum-carbon-app.cabal
@@ -1,24 +1,25 @@
-name:           fum-carbon-app
-version:        6
-synopsis:       An user management system for LDAP
-description:    ...
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-build-type:     Simple
-cabal-version:  >= 1.10
+cabal-version: 2.2
+name:          fum-carbon-app
+version:       6
+synopsis:      An user management system for LDAP
+description:   ...
+category:      Web
+homepage:      https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:   https://github.com/futurice/haskell-mega-repo/issues
+author:        Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:    Oleg Grenrus <oleg.grenrus@iki.fi>
+license:       BSD-3-Clause
+license-file:  LICENSE
+build-type:    Simple
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
   default-extensions:
     DeriveAnyClass
     DeriveDataTypeable
@@ -30,15 +31,14 @@ library
     GeneralizedNewtypeDeriving
     InstanceSigs
     ScopedTypeVariables
-  ghc-options: -Wall
   build-depends:
-      base >= 4.7 && <4.13
     , adjunctions
     , aeson
     , aeson-compat
     , ansi-pretty
     , ansi-wl-pprint
     , async
+    , base
     , bytestring
     , cassava
     , clay
@@ -78,7 +78,7 @@ library
     , process
     , QuickCheck
     , range-set-list
-    , recursion-schemes >= 5.0.1
+    , recursion-schemes       >=5.0.1
     , reflection
     , regex-applicative
     , regex-applicative-text
@@ -101,82 +101,78 @@ library
     , vector
     , writer-cps-mtl
   exposed-modules:
-      Futurice.App.FUM
-      Futurice.App.FUM.Ack
-      Futurice.App.FUM.ACL
-      Futurice.App.FUM.API
-      Futurice.App.FUM.API.Pages
-      Futurice.App.FUM.Auth
-      Futurice.App.FUM.Clay
-      Futurice.App.FUM.Command
-      Futurice.App.FUM.Command.AddEditorGroup
-      Futurice.App.FUM.Command.AddEmailToEmployee
-      Futurice.App.FUM.Command.AddEmployeeToGroup
-      Futurice.App.FUM.Command.AddSSHKeyToEmployee
-      Futurice.App.FUM.Command.Bootstrap
-      Futurice.App.FUM.Command.ChangeGroupMatch
-      Futurice.App.FUM.Command.CreateEmployee
-      Futurice.App.FUM.Command.CreateGroup
-      Futurice.App.FUM.Command.Definition
-      Futurice.App.FUM.Command.RemoveEditorGroup
-      Futurice.App.FUM.Command.RemoveEmailFromEmployee
-      Futurice.App.FUM.Command.RemoveEmployeeFromGroup
-      Futurice.App.FUM.Command.RemoveSSHKeyFromEmployee
-      Futurice.App.FUM.Command.ResetPassword
-      Futurice.App.FUM.Command.Server
-      Futurice.App.FUM.Config
-      Futurice.App.FUM.Ctx
-      Futurice.App.FUM.Lomake
-      Futurice.App.FUM.Machine
-      Futurice.App.FUM.Markup
-      Futurice.App.FUM.Pages.CreateEmployee
-      Futurice.App.FUM.Pages.CreateGroup
-      Futurice.App.FUM.Pages.Error
-      Futurice.App.FUM.Pages.FromPersonio
-      Futurice.App.FUM.Pages.Href
-      Futurice.App.FUM.Pages.Index
-      Futurice.App.FUM.Pages.ListEmployees
-      Futurice.App.FUM.Pages.ListGroups
-      Futurice.App.FUM.Pages.Server
-      Futurice.App.FUM.Pages.Summary
-      Futurice.App.FUM.Pages.ViewEmployee
-      Futurice.App.FUM.Pages.ViewGroup
-      Futurice.App.FUM.Report.CompareOldFum
-      Futurice.App.FUM.Transactor
-      Futurice.App.FUM.Types
-      Futurice.App.FUM.Types.Customer
-      Futurice.App.FUM.Types.Employee
-      Futurice.App.FUM.Types.Group
-      Futurice.App.FUM.Types.GroupMatch
-      Futurice.App.FUM.Types.GroupType
-      Futurice.App.FUM.Types.Identifier
-      Futurice.App.FUM.Types.Mailbox
-      Futurice.App.FUM.Types.Password
-      Futurice.App.FUM.Types.SSHKey
-      Futurice.App.FUM.Types.Status
-      Futurice.App.FUM.Types.UnixID
-      Futurice.App.FUM.Types.World
-  default-language: Haskell2010
+    Futurice.App.FUM
+    Futurice.App.FUM.ACL
+    Futurice.App.FUM.API
+    Futurice.App.FUM.API.Pages
+    Futurice.App.FUM.Ack
+    Futurice.App.FUM.Auth
+    Futurice.App.FUM.Clay
+    Futurice.App.FUM.Command
+    Futurice.App.FUM.Command.AddEditorGroup
+    Futurice.App.FUM.Command.AddEmailToEmployee
+    Futurice.App.FUM.Command.AddEmployeeToGroup
+    Futurice.App.FUM.Command.AddSSHKeyToEmployee
+    Futurice.App.FUM.Command.Bootstrap
+    Futurice.App.FUM.Command.ChangeGroupMatch
+    Futurice.App.FUM.Command.CreateEmployee
+    Futurice.App.FUM.Command.CreateGroup
+    Futurice.App.FUM.Command.Definition
+    Futurice.App.FUM.Command.RemoveEditorGroup
+    Futurice.App.FUM.Command.RemoveEmailFromEmployee
+    Futurice.App.FUM.Command.RemoveEmployeeFromGroup
+    Futurice.App.FUM.Command.RemoveSSHKeyFromEmployee
+    Futurice.App.FUM.Command.ResetPassword
+    Futurice.App.FUM.Command.Server
+    Futurice.App.FUM.Config
+    Futurice.App.FUM.Ctx
+    Futurice.App.FUM.Lomake
+    Futurice.App.FUM.Machine
+    Futurice.App.FUM.Markup
+    Futurice.App.FUM.Pages.CreateEmployee
+    Futurice.App.FUM.Pages.CreateGroup
+    Futurice.App.FUM.Pages.Error
+    Futurice.App.FUM.Pages.FromPersonio
+    Futurice.App.FUM.Pages.Href
+    Futurice.App.FUM.Pages.Index
+    Futurice.App.FUM.Pages.ListEmployees
+    Futurice.App.FUM.Pages.ListGroups
+    Futurice.App.FUM.Pages.Server
+    Futurice.App.FUM.Pages.Summary
+    Futurice.App.FUM.Pages.ViewEmployee
+    Futurice.App.FUM.Pages.ViewGroup
+    Futurice.App.FUM.Report.CompareOldFum
+    Futurice.App.FUM.Transactor
+    Futurice.App.FUM.Types
+    Futurice.App.FUM.Types.Customer
+    Futurice.App.FUM.Types.Employee
+    Futurice.App.FUM.Types.Group
+    Futurice.App.FUM.Types.GroupMatch
+    Futurice.App.FUM.Types.GroupType
+    Futurice.App.FUM.Types.Identifier
+    Futurice.App.FUM.Types.Mailbox
+    Futurice.App.FUM.Types.Password
+    Futurice.App.FUM.Types.SSHKey
+    Futurice.App.FUM.Types.Status
+    Futurice.App.FUM.Types.UnixID
+    Futurice.App.FUM.Types.World
 
 executable fum-carbon-server
-  main-is: Main.hs
-  hs-source-dirs:
-      srv
-  ghc-options: -Wall -Wall -threaded -rtsopts
-  build-depends:
-      base >= 4.7 && <4.13
-    , fum-carbon-app
   default-language: Haskell2010
+  main-is:          Main.hs
+  hs-source-dirs:   srv
+  ghc-options:      -Wall -Wall -threaded -rtsopts
+  build-depends:
+    , base
+    , fum-carbon-app
 
 test-suite unit-tests
-  type: exitcode-stdio-1.0
-  main-is: Tests.hs
-  hs-source-dirs:
-      tests/
-  ghc-options: -Wall
+  default-language: Haskell2010
+  type:             exitcode-stdio-1.0
+  main-is:          Tests.hs
+  hs-source-dirs:   tests/
+  ghc-options:      -Wall
   build-depends:
-      base >= 4.7 && <4.13
-    -- , fum-carbon-app
+    , base
     , futurice-prelude
     , tasty
-  default-language: Haskell2010

--- a/fum-client/fum-client.cabal
+++ b/fum-client/fum-client.cabal
@@ -1,37 +1,31 @@
--- This file has been generated from package.yaml by hpack version 0.18.1.
---
--- see: https://github.com/sol/hpack
-
-name:           fum-client
-version:        0
-synopsis:       FUM REST API
-description:    Bindings to <https://github.com/futurice/futurice-ldap-user-manager FUM API>.
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.8.4, GHC==7.10.3, GHC==8.0.1
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               fum-client
+version:            0
+synopsis:           FUM REST API
+description:
+  Bindings to <https://github.com/futurice/futurice-ldap-user-manager FUM API>.
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  ghc-options: -Wall
+  default-language: Haskell2010
+  hs-source-dirs:   src
+  ghc-options:      -Wall
   build-depends:
-      base >=4.7       && <5
     , aeson
     , aeson-compat
+    , base
     , base-compat
     , cassava
     , constraints
@@ -54,8 +48,7 @@ library
     , text
     , vector
   exposed-modules:
-      Control.Monad.FUM
-      FUM
-      FUM.Request
-      FUM.Types
-  default-language: Haskell2010
+    Control.Monad.FUM
+    FUM
+    FUM.Request
+    FUM.Types

--- a/fum-types/fum-types.cabal
+++ b/fum-types/fum-types.cabal
@@ -1,38 +1,37 @@
--- This file has been generated from package.yaml by hpack version 0.18.1.
---
--- see: https://github.com/sol/hpack
-
-name:           fum-types
-version:        0
-synopsis:       FUM types
-description:    In other words: @Login@ and @GroupName@ types
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.10.3, GHC==8.0.2
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               fum-types
+version:            0
+synopsis:           FUM types
+description:        In other words: @Login@ and @GroupName@ types
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
+  default-extensions:
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ScopedTypeVariables
   build-depends:
-      base            >=4.7      && <4.13
     , aeson
     , aeson-compat
+    , base
     , cassava
     , containers
     , env-config
@@ -40,8 +39,8 @@ library
     , futurice-prelude
     , kleene
     , lucid
-    , parsers
     , parsec
+    , parsers
     , postgresql-simple
     , QuickCheck
     , regex-applicative-text
@@ -51,6 +50,5 @@ library
     , text
     , vector
   exposed-modules:
-      FUM.Types.GroupName
-      FUM.Types.Login
-  default-language: Haskell2010
+    FUM.Types.GroupName
+    FUM.Types.Login

--- a/futuqu/futuqu.cabal
+++ b/futuqu/futuqu.cabal
@@ -1,15 +1,14 @@
 cabal-version: 2.2
-name: futuqu
-version: 0
-
-synopsis: FUTUrice QUery
-category: Integration
-description: Data to the people
+name:          futuqu
+version:       0
+synopsis:      FUTUrice QUery
+category:      Integration
+description:   Data to the people
 
 library
-  default-language: Haskell2010
-  ghc-options:      -Wall
-  hs-source-dirs:   src
+  default-language:   Haskell2010
+  ghc-options:        -Wall
+  hs-source-dirs:     src
   default-extensions:
     DeriveAnyClass
     DeriveDataTypeable
@@ -47,15 +46,15 @@ library
   exposed-modules:
     Futuqu
     Futuqu.API
-    Futuqu.NT
     Futuqu.Ggrr.HourKinds
     Futuqu.Ggrr.MissingHours
+    Futuqu.NT
     Futuqu.Rada.Accounts
     Futuqu.Rada.Capacities
     Futuqu.Rada.People
     Futuqu.Rada.Projects
     Futuqu.Rada.Tasks
     Futuqu.Rada.Timereports
+    Futuqu.Servant.CSV
     Futuqu.Strm.Capacities
     Futuqu.Strm.Timereports
-    Futuqu.Servant.CSV

--- a/futurice-chart/futurice-chart.cabal
+++ b/futurice-chart/futurice-chart.cabal
@@ -1,23 +1,29 @@
-cabal-version:  2.2
-name:           futurice-chart
-version:        0
-
-synopsis:       Chart futurice extras
-description:    Chart futurice extras: stacked, histogram, ...
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD-3-Clause
-license-file:   LICENSE
-build-type:     Simple
+cabal-version: 2.2
+name:          futurice-chart
+version:       0
+synopsis:      Chart futurice extras
+description:   Chart futurice extras: stacked, histogram, ...
+category:      Web
+homepage:      https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:   https://github.com/futurice/haskell-mega-repo/issues
+author:        Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:    Oleg Grenrus <oleg.grenrus@iki.fi>
+license:       BSD-3-Clause
+license-file:  LICENSE
+build-type:    Simple
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
+  default-language:   Haskell2010
+  ghc-options:        -Wall
+  hs-source-dirs:     src
+  default-extensions:
+    DeriveFunctor
+    DeriveGeneric
+    ScopedTypeVariables
   build-depends:
     , adjunctions
     , base
@@ -28,14 +34,7 @@ library
     , lens
     , mtl
     , vector
-  default-extensions:
-      DeriveGeneric
-      DeriveFunctor
-      ScopedTypeVariables
   exposed-modules:
-      Futurice.Chart.Enum
-      Futurice.Chart.Stacked
-      Futurice.Chart.Histogram
-  ghc-options: -Wall
-  hs-source-dirs: src
-  default-language: Haskell2010
+    Futurice.Chart.Enum
+    Futurice.Chart.Histogram
+    Futurice.Chart.Stacked

--- a/futurice-constants/futurice-constants.cabal
+++ b/futurice-constants/futurice-constants.cabal
@@ -1,30 +1,28 @@
-cabal-version:  >= 1.10
-name:           futurice-constants
-version:        0
-
-synopsis:       Futurice constants
-description:    Futurice constants
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.10.3, GHC==8.0.2
-build-type:     Simple
-
+cabal-version:      2.2
+name:               futurice-constants
+version:            0
+synopsis:           Futurice constants
+description:        Futurice constants
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
 extra-source-files:
-    README.md
-    constants.json
+  README.md
+  constants.json
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
   default-extensions:
     DeriveAnyClass
     DeriveDataTypeable
@@ -35,11 +33,10 @@ library
     DeriveTraversable
     DerivingStrategies
     ScopedTypeVariables
-  ghc-options: -Wall
   build-depends:
-      base            >=4.7      && <4.13
     , adjunctions
     , aeson-compat
+    , base
     , containers
     , distributive
     , futurice-prelude
@@ -51,8 +48,6 @@ library
     , text
     , vector
   exposed-modules:
-      Futurice.Constants
-      Futurice.Services
-  other-modules:
-      Futurice.Constants.Internal
-  default-language: Haskell2010
+    Futurice.Constants
+    Futurice.Services
+  other-modules:      Futurice.Constants.Internal

--- a/futurice-croned/futurice-croned.cabal
+++ b/futurice-croned/futurice-croned.cabal
@@ -1,12 +1,13 @@
 cabal-version: 2.2
-name: futurice-croned
-version: 0
-
-license:      BSD-3-Clause
-license-file: LICENSE
+name:          futurice-croned
+version:       0
+license:       BSD-3-Clause
+license-file:  LICENSE
 
 library
-  default-language: Haskell2010
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
   default-extensions:
     DeriveAnyClass
     DeriveDataTypeable
@@ -17,13 +18,7 @@ library
     DerivingStrategies
     GeneralizedNewtypeDeriving
     ScopedTypeVariables
-
-  hs-source-dirs: src
-  ghc-options: -Wall
-
-  exposed-modules:
-    Futurice.App.Croned
-
+  exposed-modules:    Futurice.App.Croned
   build-depends:
     , aeson
     , async
@@ -56,6 +51,6 @@ executable croned-server
   main-is:          Main.hs
   hs-source-dirs:   srv
   ghc-options:      -Wall -threaded -rtsopts
-  build-depends:    base, futurice-croned
-
-
+  build-depends:
+    , base
+    , futurice-croned

--- a/futurice-foundation/futurice-foundation.cabal
+++ b/futurice-foundation/futurice-foundation.cabal
@@ -1,29 +1,26 @@
-name:           futurice-foundation
-version:        0
-synopsis:       Futurice ZURB Foundation helpers
-description:    ...
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.8.4, GHC==7.10.3
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               futurice-foundation
+version:            0
+synopsis:           Futurice ZURB Foundation helpers
+description:        ...
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  ghc-options: -Wall
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
   default-extensions:
     DeriveDataTypeable
     DeriveFoldable
@@ -32,9 +29,9 @@ library
     DeriveTraversable
     ScopedTypeVariables
   build-depends:
-      base                  >=4.7   && <4.13
     , aeson
     , aeson-compat
+    , base
     , clay
     , colour
     , file-embed-lzma
@@ -46,7 +43,7 @@ library
     , generics-sop-lens
     , kleene
     , lambdacss
-    , language-javascript >= 0.6.0.8 && <0.7
+    , language-javascript   ^>=0.6.0.8
     , lens
     , lucid
     , servant
@@ -60,13 +57,12 @@ library
     , wai-app-static
     , writer-cps-mtl
   exposed-modules:
-      Futurice.CommandResponse
-      Futurice.Lomake
-      Futurice.JavaScript
-      Futurice.JavaScript.TH
-      Futurice.Lucid.Foundation
-      Futurice.Lucid.Generics
-      Futurice.Lucid.Navigation
-      Futurice.Lucid.Select2
-      Futurice.Lucid.Style
-  default-language: Haskell2010
+    Futurice.CommandResponse
+    Futurice.JavaScript
+    Futurice.JavaScript.TH
+    Futurice.Lomake
+    Futurice.Lucid.Foundation
+    Futurice.Lucid.Generics
+    Futurice.Lucid.Navigation
+    Futurice.Lucid.Select2
+    Futurice.Lucid.Style

--- a/futurice-github/futurice-github.cabal
+++ b/futurice-github/futurice-github.cabal
@@ -1,34 +1,37 @@
-name:           futurice-github
-version:        0
-synopsis:       Additions to the @github@ package
-description:    Additions to the @github@ package
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.8.4, GHC==7.10.3, GHC==8.0.1
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               futurice-github
+version:            0
+synopsis:           Additions to the @github@ package
+description:        Additions to the @github@ package
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall
+  default-language:   Haskell2010
+  ghc-options:        -Wall
+  hs-source-dirs:     src
+  default-extensions:
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ScopedTypeVariables
   build-depends:
-      base >=4.8   && <4.13
     , aeson
     , aeson-compat
+    , base
     , binary
     , binary-tagged
     , constraints
@@ -40,6 +43,4 @@ library
     , postgresql-simple
     , swagger2
     , text
-  exposed-modules:
-      Futurice.GitHub
-  default-language: Haskell2010
+  exposed-modules:    Futurice.GitHub

--- a/futurice-integrations/futurice-integrations.cabal
+++ b/futurice-integrations/futurice-integrations.cabal
@@ -1,31 +1,27 @@
-cabal-version:  1.12
-name:           futurice-integrations
-version:        0
-synopsis:       Tools to work uniformly with different integrations
-description:    ...
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==8.4.4
-build-type:     Simple
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               futurice-integrations
+version:            0
+synopsis:           Tools to work uniformly with different integrations
+description:        ...
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  default-language: Haskell2010
-  hs-source-dirs: src
-  ghc-options: -Wall
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
   default-extensions:
-    GeneralizedNewtypeDeriving
     DeriveAnyClass
     DeriveDataTypeable
     DeriveFoldable
@@ -33,13 +29,14 @@ library
     DeriveGeneric
     DeriveTraversable
     DerivingStrategies
+    GeneralizedNewtypeDeriving
     ScopedTypeVariables
     StandaloneDeriving
   build-depends:
-      base                  >=4.11   && <4.13
     , aeson
     , aeson-compat
     , async
+    , base
     , binary-tagged
     , bytestring
     , cassava
@@ -82,16 +79,16 @@ library
     , vector
     , zlib
   exposed-modules:
-      Futurice.Daily
-      Futurice.Integrations
-      Futurice.Integrations.Classes
-      Futurice.Integrations.Common
-      Futurice.Integrations.GitHub
-      Futurice.Integrations.Monad
-      Futurice.Integrations.Monad.StateSet
-      Futurice.Integrations.Serv
-      Futurice.Integrations.Serv.Config
-      Futurice.Integrations.Serv.Contains
-      Futurice.Integrations.Serv.FromList
-      Futurice.Integrations.TimereportKind
-      Futurice.Integrations.Types
+    Futurice.Daily
+    Futurice.Integrations
+    Futurice.Integrations.Classes
+    Futurice.Integrations.Common
+    Futurice.Integrations.GitHub
+    Futurice.Integrations.Monad
+    Futurice.Integrations.Monad.StateSet
+    Futurice.Integrations.Serv
+    Futurice.Integrations.Serv.Config
+    Futurice.Integrations.Serv.Contains
+    Futurice.Integrations.Serv.FromList
+    Futurice.Integrations.TimereportKind
+    Futurice.Integrations.Types

--- a/futurice-lambda/futurice-lambda.cabal
+++ b/futurice-lambda/futurice-lambda.cabal
@@ -1,23 +1,21 @@
 cabal-version: 2.2
-name: futurice-lambda
-version: 0
+name:          futurice-lambda
+version:       0
 
 library
-  hs-source-dirs:   src
   default-language: Haskell2010
-  exposed-modules:
-    Futurice.Lambda
-
+  hs-source-dirs:   src
+  exposed-modules:  Futurice.Lambda
   build-depends:
-    , base
     , aeson
     , amazonka
     , amazonka-cloudwatch
     , aws-lambda-runtime
+    , base
     , bytestring
     , containers
     , env-config
-    , futurice-prelude
     , futurice-metrics
+    , futurice-prelude
     , log-base
     , text

--- a/futurice-logo/futurice-logo.cabal
+++ b/futurice-logo/futurice-logo.cabal
@@ -1,53 +1,45 @@
--- This file has been generated from package.yaml by hpack version 0.18.1.
---
--- see: https://github.com/sol/hpack
-
-name:           futurice-logo
-version:        0
-synopsis:       Generate futurice logo
-description:    ... and other stuff
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.10.3, GHC==8.0.1
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               futurice-logo
+version:            0
+synopsis:           Generate futurice logo
+description:        ... and other stuff
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  ghc-options: -Wall
+  default-language: Haskell2010
+  hs-source-dirs:   src
+  ghc-options:      -Wall
   build-depends:
-      base                  >=4.7      && <4.13
-    , futurice-prelude
-    , JuicyPixels           >=3.2.7    && <3.4
-    , base-compat           >=0.6      && <0.11
-    , bytestring            >=0.10.4.0 && <0.11
+    , base                 >=4.7 && <4.13
+    , base-compat          >=0.6 && <0.11
+    , bytestring           ^>=0.10.4.0
     , clay
     , colour
-    , deepseq               >=1.3.0.2  && <1.5
-    , file-embed            >=0.0.8.2  && <0.0.12
-    , hashable              >=1.2.3.3  && <1.3
-    , http-media            >=0.6.2    && <0.8
-    , servant               >=0.4.4.5  && <0.16
-    , servant-server        >=0.4.4.5  && <0.16
-    , tagged                >=0.7.3    && <0.9
-    , swagger2              >=2.0      && <2.4
+    , deepseq              >=1.3.0.2 && <1.5
+    , file-embed           >=0.0.8.2 && <0.0.12
+    , futurice-prelude
+    , hashable             ^>=1.2.3.3
+    , http-media           >=0.6.2 && <0.8
+    , JuicyPixels          >=3.2.7 && <3.4
+    , servant              >=0.4.4.5 && <0.16
+    , servant-JuicyPixels  ^>=0.3.0.0
+    , servant-server       >=0.4.4.5 && <0.16
+    , swagger2             >=2.0 && <2.4
+    , tagged               >=0.7.3 && <0.9
     , text
-    , servant-JuicyPixels   >=0.3.0.0  && <0.4
   exposed-modules:
-      Futurice.Colour
-      Futurice.Logo
-      Servant.Futurice.Favicon
-  default-language: Haskell2010
+    Futurice.Colour
+    Futurice.Logo
+    Servant.Futurice.Favicon

--- a/futurice-metrics/futurice-metrics.cabal
+++ b/futurice-metrics/futurice-metrics.cabal
@@ -1,38 +1,35 @@
--- This file has been generated from package.yaml by hpack version 0.18.1.
---
--- see: https://github.com/sol/hpack
-
-name:           futurice-metrics
-version:        0
-synopsis:       Rudimenatry metrics, like ekg
-description:    ...
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==8.0.2, GHC==8.2.1
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               futurice-metrics
+version:            0
+synopsis:           Rudimenatry metrics, like ekg
+description:        ...
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
+  default-extensions:
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ScopedTypeVariables
   build-depends:
-      base                  >=4.7 && <5
+    , base
     , futurice-prelude
     , stm
-  exposed-modules:
-      Futurice.Metrics.RateMeter
-  default-language: Haskell2010
+  exposed-modules:    Futurice.Metrics.RateMeter

--- a/futurice-postgres/futurice-postgres.cabal
+++ b/futurice-postgres/futurice-postgres.cabal
@@ -1,34 +1,36 @@
-cabal-version:  2.2
-name:           futurice-postgres
-version:        0
-
-synopsis:       Postgres stuff
-description:    ...
-category:       Database
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD-3-Clause
-license-file:   LICENSE
-tested-with:    GHC==8.0.2, GHC==8.2.1
-build-type:     Simple
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               futurice-postgres
+version:            0
+synopsis:           Postgres stuff
+description:        ...
+category:           Database
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall
+  default-language:   Haskell2010
+  ghc-options:        -Wall
+  hs-source-dirs:     src
+  default-extensions:
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ScopedTypeVariables
   build-depends:
-    , base
     , aeson-compat
+    , base
     , containers
     , exceptions
     , futurice-metrics
@@ -39,6 +41,5 @@ library
     , resource-pool
     , semigroups
   exposed-modules:
-      Futurice.Postgres
-      Futurice.Postgres.SqlBuilder
-  default-language: Haskell2010
+    Futurice.Postgres
+    Futurice.Postgres.SqlBuilder

--- a/futurice-pure-trans/futurice-pure-trans.cabal
+++ b/futurice-pure-trans/futurice-pure-trans.cabal
@@ -1,37 +1,36 @@
--- This file has been generated from package.yaml by hpack version 0.18.1.
---
--- see: https://github.com/sol/hpack
-
-name:           futurice-pure-trans
-version:        0
-synopsis:       A reader monad transformer to provide context to IO
-description:    A reader monad transformer to provide context to IO
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.10.3, GHC==8.0.2
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               futurice-pure-trans
+version:            0
+synopsis:           A reader monad transformer to provide context to IO
+description:        A reader monad transformer to provide context to IO
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  default-extensions:
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ScopedTypeVariables
+  ghc-options:        -Wall
   build-depends:
-      base                  >=4.7   && <4.13
     , aeson
+    , base
     , futurice-prelude
     , http-client
     , lens
@@ -41,6 +40,4 @@ library
     , monadcryptorandom
     , resource-pool
     , unordered-containers
-  exposed-modules:
-      Futurice.Trans.PureT
-  default-language: Haskell2010
+  exposed-modules:    Futurice.Trans.PureT

--- a/futurice-reports/futurice-reports.cabal
+++ b/futurice-reports/futurice-reports.cabal
@@ -1,38 +1,37 @@
--- This file has been generated from package.yaml by hpack version 0.18.1.
---
--- see: https://github.com/sol/hpack
-
-name:           futurice-reports
-version:        0
-synopsis:       Various reports utils
-description:    ...
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.8.4, GHC==7.10.3, GHC==8.0.1
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               futurice-reports
+version:            0
+synopsis:           Various reports utils
+description:        ...
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
+  default-extensions:
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ScopedTypeVariables
   build-depends:
-      base                  >=4.7   && <4.13
     , aeson
     , aeson-compat
+    , base
     , cassava
     , constraints
     , containers
@@ -56,6 +55,4 @@ library
     , text
     , these
     , transformers
-  exposed-modules:
-      Futurice.Report.Columns
-  default-language: Haskell2010
+  exposed-modules:    Futurice.Report.Columns

--- a/futurice-servant/futurice-servant.cabal
+++ b/futurice-servant/futurice-servant.cabal
@@ -1,28 +1,26 @@
-name:           futurice-servant
-version:        0
-synopsis:       Collection of utilities for servant
-description:    ...
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.8.4, GHC==7.10.3, GHC==8.0.1
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               futurice-servant
+version:            0
+synopsis:           Collection of utilities for servant
+description:        ...
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
+  default-language:   Haskell2010
+  ghc-options:        -Wall
+  hs-source-dirs:     src
   default-extensions:
     DeriveDataTypeable
     DeriveFoldable
@@ -30,9 +28,7 @@ library
     DeriveGeneric
     DeriveTraversable
     ScopedTypeVariables
-  ghc-options: -Wall
   build-depends:
-      base                  >=4.7 && <5
     , adjunctions
     , aeson
     , amazonka
@@ -40,6 +36,7 @@ library
     , amazonka-cloudwatch-logs
     , amazonka-sns
     , amazonka-sqs
+    , base
     , base-compat
     , bytestring
     , containers
@@ -55,7 +52,7 @@ library
     , futurice-metrics
     , futurice-prelude
     , ghc-prim
-    , gitrev >=1.2.0
+    , gitrev                    >=1.2.0
     , http-media
     , http-types
     , lens
@@ -63,7 +60,9 @@ library
     , lzma
     , optparse-applicative
     , periocron
+    , regex-applicative
     , regex-applicative-text
+    , resourcet
     , servant
     , servant-cassava
     , servant-lucid
@@ -71,7 +70,6 @@ library
     , servant-swagger
     , servant-swagger-ui
     , split
-    , regex-applicative
     , stm
     , swagger2
     , text
@@ -80,13 +78,10 @@ library
     , vector
     , wai
     , wai-extra
-    , warp >= 3.2.11.1
+    , warp                      >=3.2.11.1
     , zlib
-
-    , resourcet
   exposed-modules:
-      Futurice.KleeneSwagger
-      Futurice.Servant
-      Futurice.MessageQueue
-      Futurice.Wai.ContentMiddleware
-  default-language: Haskell2010
+    Futurice.KleeneSwagger
+    Futurice.MessageQueue
+    Futurice.Servant
+    Futurice.Wai.ContentMiddleware

--- a/futurice-signed/futurice-signed.cabal
+++ b/futurice-signed/futurice-signed.cabal
@@ -1,41 +1,39 @@
-cabal-version:  2.2
-name:           futurice-signed
-version:        0
-
-synopsis:       Signed data
-description:    Signed data
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD-3-Clause
-license-file:   LICENSE
-build-type:     Simple
+cabal-version: 2.2
+name:          futurice-signed
+version:       0
+synopsis:      Signed data
+description:   Signed data
+category:      Web
+homepage:      https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:   https://github.com/futurice/haskell-mega-repo/issues
+author:        Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:    Oleg Grenrus <oleg.grenrus@iki.fi>
+license:       BSD-3-Clause
+license-file:  LICENSE
+build-type:    Simple
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
+  default-language:   Haskell2010
+  ghc-options:        -Wall
+  hs-source-dirs:     src
+  default-extensions:
+    DeriveFunctor
+    DeriveGeneric
+    ScopedTypeVariables
   build-depends:
-    , base
     , aeson
+    , base
     , base16-bytestring
     , containers
     , cryptohash-sha512
     , ed25519
     , futurice-prelude
+    , insert-ordered-containers
     , serialise
     , swagger2
-    , insert-ordered-containers
     , unordered-containers
-  default-extensions:
-      DeriveGeneric
-      DeriveFunctor
-      ScopedTypeVariables
-  exposed-modules:
-      Futurice.Signed
-  ghc-options: -Wall
-  hs-source-dirs: src
-  default-language: Haskell2010
+  exposed-modules:    Futurice.Signed

--- a/futurice-tribes/futurice-tribes.cabal
+++ b/futurice-tribes/futurice-tribes.cabal
@@ -1,43 +1,39 @@
-name:           futurice-tribes
-version:        0
-synopsis:       Futurice tribes
-description:    Futurice tribes and locations
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.10.3, GHC==8.0.2
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               futurice-tribes
+version:            0
+synopsis:           Futurice tribes
+description:        Futurice tribes and locations
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
   default-extensions:
+    DeriveAnyClass
     DeriveDataTypeable
     DeriveFoldable
     DeriveFunctor
     DeriveGeneric
     DeriveTraversable
-    DeriveAnyClass
     DerivingStrategies
     ScopedTypeVariables
-  ghc-options: -Wall
   build-depends:
-      base            >=4.7      && <4.13
-    , QuickCheck
     , aeson
     , aeson-compat
+    , base
     , cassava
     , containers
     , env-config
@@ -46,6 +42,7 @@ library
     , http-api-data
     , kleene
     , lucid
+    , QuickCheck
     , regex-applicative
     , regex-applicative-text
     , swagger2
@@ -54,16 +51,15 @@ library
     , trifecta
     , vector
   exposed-modules:
-      Futurice.CareerLevel
-      Futurice.Company
-      Futurice.CostCenter
-      Futurice.Email
-      Futurice.Office
-      Futurice.Tribe
+    Futurice.CareerLevel
+    Futurice.Company
+    Futurice.CostCenter
+    Futurice.Email
+    Futurice.Office
+    Futurice.Tribe
   other-modules:
-      Futurice.CareerLevel.Internal
-      Futurice.Company.Internal
-      Futurice.CostCenter.Internal
-      Futurice.Office.Internal
-      Futurice.Tribe.Internal
-  default-language: Haskell2010
+    Futurice.CareerLevel.Internal
+    Futurice.Company.Internal
+    Futurice.CostCenter.Internal
+    Futurice.Office.Internal
+    Futurice.Tribe.Internal

--- a/github-proxy/github-proxy.cabal
+++ b/github-proxy/github-proxy.cabal
@@ -1,55 +1,55 @@
-name:           github-proxy
-version:        0
-synopsis:       GitHub proxy
-description:    New and fancy
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.8.4, GHC==7.10.3, GHC==8.0.1
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               github-proxy
+version:            0
+synopsis:           GitHub proxy
+description:        New and fancy
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall
+  hs-source-dirs:     src
+  ghc-options:        -Wall -freduction-depth=30
+  default-extensions:
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ScopedTypeVariables
   build-depends:
-      base >=4.7   && <4.13
+    , aeson
+    , base
+    , binary
+    , binary-tagged
+    , bytestring
     , constraints
+    , containers
     , env-config
+    , exceptions
     , futurice-github
     , futurice-integrations
     , futurice-metrics
     , futurice-postgres
     , futurice-prelude
+    , futurice-servant
     , github
     , http-client
     , http-client-tls
     , intervals
-    , operational
-    , time-parsers >=0.1.1.0
-    , aeson
-    , binary
-    , binary-tagged
-    , bytestring
-    , containers
-    , exceptions
-    , futurice-servant
-    , intervals
     , lens
     , monad-logger
+    , operational
     , periocron
     , postgresql-simple
     , postgresql-simple-url
@@ -60,29 +60,32 @@ library
     , swagger2
     , text
     , time
+    , time-parsers           >=0.1.1.0
     , unordered-containers
     , vector
-  if impl(ghc >= 8.0)
-    ghc-options: -freduction-depth=30
-  else
-    ghc-options: -fcontext-stack=30
   exposed-modules:
-      Futurice.App.GitHubProxy
-      Futurice.App.GitHubProxy.API
-      Futurice.App.GitHubProxy.Config
-      Futurice.App.GitHubProxy.H
-      Futurice.App.GitHubProxy.Logic
-      Futurice.App.GitHubProxy.Types
-  default-language: Haskell2010
+    Futurice.App.GitHubProxy
+    Futurice.App.GitHubProxy.API
+    Futurice.App.GitHubProxy.Config
+    Futurice.App.GitHubProxy.H
+    Futurice.App.GitHubProxy.Logic
+    Futurice.App.GitHubProxy.Types
+  default-language:   Haskell2010
 
 executable github-proxy-client
-  main-is: Main.hs
-  hs-source-dirs:
-      cli
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall -threaded -rtsopts
+  default-language:   Haskell2010
+  main-is:            Main.hs
+  ghc-options:        -Wall -threaded -rtsopts
+  hs-source-dirs:     cli
+  default-extensions:
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ScopedTypeVariables
   build-depends:
-      base >=4.7   && <4.13
+    , base
     , constraints
     , env-config
     , futurice-github
@@ -90,42 +93,25 @@ executable github-proxy-client
     , futurice-metrics
     , futurice-prelude
     , github
+    , haxl
     , http-client
     , http-client-tls
     , intervals
     , operational
-    , time-parsers >=0.1.1.0
-    , haxl
-  if impl(ghc >= 8.0)
-    ghc-options: -freduction-depth=30
-  else
-    ghc-options: -fcontext-stack=30
-  default-language: Haskell2010
+    , time-parsers
 
 executable github-proxy-server
-  main-is: Main.hs
-  hs-source-dirs:
-      srv
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall -threaded -rtsopts
+  default-language:   Haskell2010
+  main-is:            Main.hs
+  hs-source-dirs:     srv
+  ghc-options:        -Wall -threaded -rtsopts
+  default-extensions:
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ScopedTypeVariables
   build-depends:
-      base >=4.7   && <4.13
-    , constraints
-    , env-config
-    , futurice-github
-    , futurice-integrations
-    , futurice-metrics
-    , futurice-postgres
-    , futurice-prelude
-    , github
-    , http-client
-    , http-client-tls
-    , intervals
-    , operational
-    , time-parsers >=0.1.1.0
+    , base
     , github-proxy
-  if impl(ghc >= 8.0)
-    ghc-options: -freduction-depth=30
-  else
-    ghc-options: -fcontext-stack=30
-  default-language: Haskell2010

--- a/github-sync/github-sync.cabal
+++ b/github-sync/github-sync.cabal
@@ -1,34 +1,37 @@
-name:           github-sync
-version:        0
-synopsis:       Manage GitHub
-description:    New and fancy
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.10.3
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               github-sync
+version:            0
+synopsis:           Manage GitHub
+description:        New and fancy
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall -freduction-depth=30
+  default-extensions:
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ScopedTypeVariables
   build-depends:
-      base                  >=4.7   && <4.13
     , aeson
     , aeson-compat
+    , base
     , clay
     , containers
     , env-config
@@ -49,32 +52,21 @@ library
     , servant
     , servant-lucid
     , servant-server
-  if impl(ghc >= 8.0)
-    ghc-options: -freduction-depth=30
-  else
-    ghc-options: -fcontext-stack=30
   exposed-modules:
-      Futurice.App.GitHubSync.API
-      Futurice.App.GitHubSync.AuditPage
-      Futurice.App.GitHubSync.Config
-      Futurice.App.GitHubSync.Ctx
-      Futurice.App.GitHubSync.IndexPage
-      Futurice.App.GitHubSync.Main
-      Futurice.App.GitHubSync.Markup
-      Futurice.App.GitHubSync.RemoveUsers
-  default-language: Haskell2010
+    Futurice.App.GitHubSync.API
+    Futurice.App.GitHubSync.AuditPage
+    Futurice.App.GitHubSync.Config
+    Futurice.App.GitHubSync.Ctx
+    Futurice.App.GitHubSync.IndexPage
+    Futurice.App.GitHubSync.Main
+    Futurice.App.GitHubSync.Markup
+    Futurice.App.GitHubSync.RemoveUsers
 
 executable github-sync-server
-  main-is: Main.hs
-  hs-source-dirs:
-      srv
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall -threaded -rtsopts
-  build-depends:
-      base
-    , github-sync
-  if impl(ghc >= 8.0)
-    ghc-options: -freduction-depth=30
-  else
-    ghc-options: -fcontext-stack=30
   default-language: Haskell2010
+  main-is:          Main.hs
+  hs-source-dirs:   srv
+  ghc-options:      -Wall -threaded -rtsopts
+  build-depends:
+    , base
+    , github-sync

--- a/haxl-fxtra/haxl-fxtra.cabal
+++ b/haxl-fxtra/haxl-fxtra.cabal
@@ -1,42 +1,41 @@
--- This file has been generated from package.yaml by hpack version 0.18.1.
---
--- see: https://github.com/sol/hpack
-
-name:           haxl-fxtra
-version:        0
-synopsis:       Futurice extras for Haxl
-description:    Mostly bindings to various datasources
-category:       Web
-homepage:       https://github.com/futurice/haskell-haxl-fxtra#readme
-bug-reports:    https://github.com/futurice/haskell-haxl-fxtra/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.10.3, GHC==8.0.1
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               haxl-fxtra
+version:            0
+synopsis:           Futurice extras for Haxl
+description:        Mostly bindings to various datasources
+category:           Web
+homepage:           https://github.com/futurice/haskell-haxl-fxtra#readme
+bug-reports:        https://github.com/futurice/haskell-haxl-fxtra/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-haxl-fxtra
 
 library
-  hs-source-dirs:
-      src
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
+  default-extensions:
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ScopedTypeVariables
   build-depends:
-      base                  >=4.7      && <4.13
     , aeson
     , aeson-compat
+    , base
     , bifunctors
     , bytestring
     , exceptions
-    , flowdock-rest         >=0.2.0.0
+    , flowdock-rest        >=0.2.0.0
     , fum-client
     , futurice-prelude
     , github
@@ -52,9 +51,8 @@ library
     , text
     , vector
   exposed-modules:
-      Flowdock.Haxl
-      FUM.Haxl
-      Github.Haxl
-      Personio.Haxl
-      Power.Haxl
-  default-language: Haskell2010
+    FUM.Haxl
+    Flowdock.Haxl
+    Github.Haxl
+    Personio.Haxl
+    Power.Haxl

--- a/hc-app/hc-app.cabal
+++ b/hc-app/hc-app.cabal
@@ -1,100 +1,98 @@
-name:           hc-app
-version:        0
-synopsis:       Tools for HC
-description:    Tools for HC.
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-build-type:     Simple
-cabal-version:  >= 1.10
+cabal-version: 2.2
+name:          hc-app
+version:       0
+synopsis:      Tools for HC
+description:   Tools for HC.
+category:      Web
+homepage:      https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:   https://github.com/futurice/haskell-mega-repo/issues
+author:        Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:    Oleg Grenrus <oleg.grenrus@iki.fi>
+license:       BSD-3-Clause
+license-file:  LICENSE
+build-type:    Simple
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
   default-extensions:
+    DeriveAnyClass
     DeriveDataTypeable
     DeriveFoldable
     DeriveFunctor
     DeriveGeneric
     DeriveTraversable
-    ScopedTypeVariables
     DerivingStrategies
-    DeriveAnyClass
-  ghc-options: -Wall
+    ScopedTypeVariables
   build-depends:
-      base >= 4.9 && <4.13,
-      aeson,
-      base16-bytestring,
-      base64-bytestring-type,
-      binary,
-      Chart,
-      clay,
-      containers,
-      cryptohash-sha512,
-      email-proxy-client,
-      entropy,
-      env-config,
-      file-embed,
-      fin,
-      fum-api,
-      fum-types,
-      futurice-foundation,
-      futurice-integrations,
-      futurice-logo,
-      futurice-prelude,
-      futurice-servant,
-      futurice-tribes,
-      http-api-data,
-      intervals,
-      lattices,
-      lens,
-      microstache,
-      personio-client,
-      planmill-client,
-      range-set-list,
-      servant,
-      servant-Chart,
-      servant-client,
-      servant-server,
-      swagger2,
-      template-haskell,
-      text,
-      time,
-      vec,
-      unordered-containers
- 
+    , aeson
+    , base
+    , base16-bytestring
+    , base64-bytestring-type
+    , binary
+    , Chart
+    , clay
+    , containers
+    , cryptohash-sha512
+    , email-proxy-client
+    , entropy
+    , env-config
+    , file-embed
+    , fin
+    , fum-api
+    , fum-types
+    , futurice-foundation
+    , futurice-integrations
+    , futurice-logo
+    , futurice-prelude
+    , futurice-servant
+    , futurice-tribes
+    , http-api-data
+    , intervals
+    , lattices
+    , lens
+    , microstache
+    , personio-client
+    , planmill-client
+    , range-set-list
+    , servant
+    , servant-Chart
+    , servant-client
+    , servant-server
+    , swagger2
+    , template-haskell
+    , text
+    , time
+    , unordered-containers
+    , vec
   exposed-modules:
-      Futurice.App.HC.Achoo.Fetch
-      Futurice.App.HC.Achoo.Render
-      Futurice.App.HC.Achoo.Types
-      Futurice.App.HC.Anniversaries
-      Futurice.App.HC.API
-      Futurice.App.HC.Config
-      Futurice.App.HC.Ctx
-      Futurice.App.HC.EarlyCaring.Page
-      Futurice.App.HC.EarlyCaring.Template
-      Futurice.App.HC.EarlyCaring.Types
-      Futurice.App.HC.HRNumbers
-      Futurice.App.HC.IndexPage
-      Futurice.App.HC.Main
-      Futurice.App.HC.Markup
-      Futurice.App.HC.PersonioValidation
-      Futurice.App.HC.PrivateContacts
-
-  default-language: Haskell2010
+    Futurice.App.HC.API
+    Futurice.App.HC.Achoo.Fetch
+    Futurice.App.HC.Achoo.Render
+    Futurice.App.HC.Achoo.Types
+    Futurice.App.HC.Anniversaries
+    Futurice.App.HC.Config
+    Futurice.App.HC.Ctx
+    Futurice.App.HC.EarlyCaring.Page
+    Futurice.App.HC.EarlyCaring.Template
+    Futurice.App.HC.EarlyCaring.Types
+    Futurice.App.HC.HRNumbers
+    Futurice.App.HC.IndexPage
+    Futurice.App.HC.Main
+    Futurice.App.HC.Markup
+    Futurice.App.HC.PersonioValidation
+    Futurice.App.HC.PrivateContacts
 
 executable hc-app-server
-  main-is: Main.hs
-  hs-source-dirs:
-      srv
-  ghc-options: -Wall -Wall -threaded -rtsopts
-  build-depends: base, hc-app
   default-language: Haskell2010
+  main-is:          Main.hs
+  hs-source-dirs:   srv
+  ghc-options:      -Wall -Wall -threaded -rtsopts
+  build-depends:
+    , base
+    , hc-app

--- a/hours-api/hours-api.cabal
+++ b/hours-api/hours-api.cabal
@@ -1,34 +1,39 @@
-name:           hours-api
-version:        0
-synopsis:       Hours API
-description:    Hours API: Actual server and mock
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>, Jussi Vaihia <jussi.vaihia@futurice.com>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.10.3, GHC==8.0.2, GHC==8.2.1
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               hours-api
+version:            0
+synopsis:           Hours API
+description:        Hours API: Actual server and mock
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:
+  Oleg Grenrus <oleg.grenrus@iki.fi>, Jussi Vaihia <jussi.vaihia@futurice.com>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
+  default-extensions:
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ScopedTypeVariables
   build-depends:
-      base >= 4.8 && <4.13
     , aeson
     , aeson-compat
     , avatar-client
+    , base
     , constraints
     , containers
     , dynmap-cache
@@ -71,40 +76,35 @@ library
     , unordered-containers
     , vector
   exposed-modules:
-      Futurice.App.HoursApi
-      Futurice.App.HoursApi.API
-      Futurice.App.HoursApi.Class
-      Futurice.App.HoursApi.Config
-      Futurice.App.HoursApi.Ctx
-      Futurice.App.HoursApi.Logic
-      Futurice.App.HoursApi.Monad
-      Futurice.App.HoursApi.Types
-      Futurice.App.HoursMock
-      Futurice.App.HoursMock.Config
-      Futurice.App.HoursMock.Ctx
-      Futurice.App.HoursMock.MockData
-      Futurice.App.HoursMock.Monad
-      Futurice.App.HoursMock.World
-  default-language: Haskell2010
+    Futurice.App.HoursApi
+    Futurice.App.HoursApi.API
+    Futurice.App.HoursApi.Class
+    Futurice.App.HoursApi.Config
+    Futurice.App.HoursApi.Ctx
+    Futurice.App.HoursApi.Logic
+    Futurice.App.HoursApi.Monad
+    Futurice.App.HoursApi.Types
+    Futurice.App.HoursMock
+    Futurice.App.HoursMock.Config
+    Futurice.App.HoursMock.Ctx
+    Futurice.App.HoursMock.MockData
+    Futurice.App.HoursMock.Monad
+    Futurice.App.HoursMock.World
 
 executable hours-api-server
-  main-is: Main.hs
-  hs-source-dirs:
-      srv
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -threaded -rtsopts
-  build-depends:
-      base
-    , hours-api
   default-language: Haskell2010
+  main-is:          Main.hs
+  hs-source-dirs:   srv
+  ghc-options:      -threaded -rtsopts
+  build-depends:
+    , base
+    , hours-api
 
 executable hours-mock-server
-  main-is: Main.hs
-  hs-source-dirs:
-      mock
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -threaded -rtsopts
-  build-depends:
-      base
-    , hours-api
   default-language: Haskell2010
+  main-is:          Main.hs
+  hs-source-dirs:   mock
+  ghc-options:      -threaded -rtsopts
+  build-depends:
+    , base
+    , hours-api

--- a/lambdacss/lambdacss.cabal
+++ b/lambdacss/lambdacss.cabal
@@ -1,60 +1,59 @@
-name:           lambdacss
-version:        0
-synopsis:       CSS utils
-description:    Copy from README when ready
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==8.0.2, GHC==8.2.2
-build-type:     Simple
-cabal-version:  >= 1.10
-extra-source-files:
-  README.md
+cabal-version:      2.2
+name:               lambdacss
+version:            0
+synopsis:           CSS utils
+description:        Copy from README when ready
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
+  default-language: Haskell2010
+  ghc-options:      -Wall
+  hs-source-dirs:   src
   build-depends:
-    base >= 4.9 && <4.13,
-    bytestring,
-    containers,
-    colour,
-    lens,
-    parsers,
-    text,
-    scientific,
-    trifecta
+    , base
+    , bytestring
+    , colour
+    , containers
+    , lens
+    , parsers
+    , scientific
+    , text
+    , trifecta
   other-extensions:
-    OverloadedStrings DeriveGeneric
+    DeriveGeneric
+    OverloadedStrings
   exposed-modules:
     LambdaCSS
     LambdaCSS.Parser
     LambdaCSS.Printer
     LambdaCSS.Types
-  ghc-options: -Wall
-  hs-source-dirs: src
-  default-language: Haskell2010
 
 test-suite fixtures
-  type: exitcode-stdio-1.0
-  ghc-options: -Wall
+  type:             exitcode-stdio-1.0
+  ghc-options:      -Wall
   default-language: Haskell2010
-  hs-source-dirs: test
-  main-is: Tests.hs
+  hs-source-dirs:   test
+  main-is:          Tests.hs
   build-depends:
-    base,
-    ansi-terminal,
-    bytestring,
-    filepath,
-    lambdacss,
-    tasty,
-    tasty-hunit,
-    text,
-    tree-diff,
-    trifecta
+    , ansi-terminal
+    , base
+    , bytestring
+    , filepath
+    , lambdacss
+    , tasty
+    , tasty-hunit
+    , text
+    , tree-diff
+    , trifecta

--- a/library-app/library-app.cabal
+++ b/library-app/library-app.cabal
@@ -1,26 +1,25 @@
-cabal-version:  2.2
-name:           library-app
-version:        0
-
-synopsis:       Book catalogy and loaning service
-description:    ...
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Toni Okuogume <toni.okuogume@futurice.com>
-maintainer:     Toni Okuogume <toni.okuogume@futurice.com>
-license:        BSD-3-Clause
-license-file:   LICENSE
-build-type:     Simple
+cabal-version: 2.2
+name:          library-app
+version:       0
+synopsis:      Book catalogy and loaning service
+description:   ...
+category:      Web
+homepage:      https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:   https://github.com/futurice/haskell-mega-repo/issues
+author:        Toni Okuogume <toni.okuogume@futurice.com>
+maintainer:    Toni Okuogume <toni.okuogume@futurice.com>
+license:       BSD-3-Clause
+license-file:  LICENSE
+build-type:    Simple
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  default-language: Haskell2010
-  hs-source-dirs: src
-  ghc-options: -Wall
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
   default-extensions:
     DeriveAnyClass
     DeriveDataTypeable
@@ -33,94 +32,92 @@ library
     ScopedTypeVariables
     StandaloneDeriving
   build-depends:
-      , base
-      , aeson
-      , base64-bytestring
-      , bytestring
-      , containers
-      , cryptohash-sha256
-      , email-proxy-client
-      , env-config
-      , fum-api
-      , fum-types
-      , futurice-constants
-      , futurice-foundation
-      , futurice-integrations
-      , futurice-postgres
-      , futurice-prelude
-      , futurice-servant
-      , futurice-tribes
-      , http-api-data
-      , http-client
-      , http-types
-      , JuicyPixels
-      , lens
-      , personio-client
-      , postgresql-simple
-      , servant
-      , servant-client
-      , servant-JuicyPixels
-      , servant-lucid
-      , servant-multipart
-      , servant-server
-      , sisosota-client
-      , swagger2
-      , text
-      , time
-      , xeno
-
+    , aeson
+    , base
+    , base64-bytestring
+    , bytestring
+    , containers
+    , cryptohash-sha256
+    , email-proxy-client
+    , env-config
+    , fum-api
+    , fum-types
+    , futurice-constants
+    , futurice-foundation
+    , futurice-integrations
+    , futurice-postgres
+    , futurice-prelude
+    , futurice-servant
+    , futurice-tribes
+    , http-api-data
+    , http-client
+    , http-types
+    , JuicyPixels
+    , lens
+    , personio-client
+    , postgresql-simple
+    , servant
+    , servant-client
+    , servant-JuicyPixels
+    , servant-lucid
+    , servant-multipart
+    , servant-server
+    , sisosota-client
+    , swagger2
+    , text
+    , time
+    , xeno
   exposed-modules:
-      Futurice.App.Library
-      Futurice.App.Library.API
-      Futurice.App.Library.Ctx
-      Futurice.App.Library.Config
-      Futurice.App.Library.Logic
-      Futurice.App.Library.Logic.Informations
-      Futurice.App.Library.Markup
-      Futurice.App.Library.Reminder
-      Futurice.App.Library.Pages.AddItemPage
-      Futurice.App.Library.Pages.BoardGameInformationPage
-      Futurice.App.Library.Pages.BookInformationPage
-      Futurice.App.Library.Pages.EditItemPage
-      Futurice.App.Library.Pages.IndexPage
-      Futurice.App.Library.Pages.PersonalLoansPage
-      Futurice.App.Library.Types
-      Futurice.App.Library.Types.AddItemRequest
-      Futurice.App.Library.Types.BoardGameInformation
-      Futurice.App.Library.Types.BoardGameInformationResponse
-      Futurice.App.Library.Types.BookInformation
-      Futurice.App.Library.Types.BookInformationResponse
-      Futurice.App.Library.Types.BookInformationByISBNResponse
-      Futurice.App.Library.Types.BorrowRequest
-      Futurice.App.Library.Types.EditItemRequest
-      Futurice.App.Library.Types.Item
-      Futurice.App.Library.Types.ItemType
-      Futurice.App.Library.Types.Library
-      Futurice.App.Library.Types.Loan
-      Futurice.App.Library.Types.Search
+    Futurice.App.Library
+    Futurice.App.Library.API
+    Futurice.App.Library.Config
+    Futurice.App.Library.Ctx
+    Futurice.App.Library.Logic
+    Futurice.App.Library.Logic.Informations
+    Futurice.App.Library.Markup
+    Futurice.App.Library.Pages.AddItemPage
+    Futurice.App.Library.Pages.BoardGameInformationPage
+    Futurice.App.Library.Pages.BookInformationPage
+    Futurice.App.Library.Pages.EditItemPage
+    Futurice.App.Library.Pages.IndexPage
+    Futurice.App.Library.Pages.PersonalLoansPage
+    Futurice.App.Library.Reminder
+    Futurice.App.Library.Types
+    Futurice.App.Library.Types.AddItemRequest
+    Futurice.App.Library.Types.BoardGameInformation
+    Futurice.App.Library.Types.BoardGameInformationResponse
+    Futurice.App.Library.Types.BookInformation
+    Futurice.App.Library.Types.BookInformationByISBNResponse
+    Futurice.App.Library.Types.BookInformationResponse
+    Futurice.App.Library.Types.BorrowRequest
+    Futurice.App.Library.Types.EditItemRequest
+    Futurice.App.Library.Types.Item
+    Futurice.App.Library.Types.ItemType
+    Futurice.App.Library.Types.Library
+    Futurice.App.Library.Types.Loan
+    Futurice.App.Library.Types.Search
 
 executable library-app-server
-  main-is: Main.hs
-  hs-source-dirs:
-      srv
-  ghc-options: -Wall -Wall -threaded -rtsopts
-  build-depends:
-      base >= 4.7 && <4.13
-    , futurice-prelude
-    , library-app
   default-language: Haskell2010
+  main-is:          Main.hs
+  hs-source-dirs:   srv
+  ghc-options:      -Wall -Wall -threaded -rtsopts
+  build-depends:
+    , base
+    , library-app
 
 test-suite unit-tests
-  type: exitcode-stdio-1.0
-  main-is: Tests.hs
-  hs-source-dirs:
-      tests/
-  ghc-options: -Wall
+  default-language: Haskell2010
+  type:             exitcode-stdio-1.0
+  main-is:          Tests.hs
+  hs-source-dirs:   tests/
+  ghc-options:      -Wall
   build-depends:
-      base
+    , base
     , env-config
     , futurice-postgres
     , futurice-prelude
+    , library-app
     , log-base
     , postgresql-simple
     , sisosota-client
@@ -129,5 +126,3 @@ test-suite unit-tests
     , tasty-hunit
     , tasty-quickcheck
     , text
-    , library-app
-  default-language: Haskell2010

--- a/log-cloudwatch/log-cloudwatch.cabal
+++ b/log-cloudwatch/log-cloudwatch.cabal
@@ -1,43 +1,43 @@
-name:           log-cloudwatch
-version:        0
-synopsis:       CloudWatch Logs backend for log
-description:    CloudWatch Logs backend for log
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.8.4, GHC==7.10.3, GHC==8.0.2
-build-type:     Simple
-cabal-version:  2.0
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               log-cloudwatch
+version:            0
+synopsis:           CloudWatch Logs backend for log
+description:        CloudWatch Logs backend for log
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  default-extensions:
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ScopedTypeVariables
+  ghc-options:        -Wall
   build-depends:
-      base                      >=4.7 && <4.13
-    , amazonka                 ^>=1.5.0 || ^>=1.6.0
-    , amazonka-cloudwatch-logs ^>=1.5.0 || ^>=1.6.0
-    , base-compat-batteries    ^>=0.10.1
+    , amazonka                  ^>=1.6.0
+    , amazonka-cloudwatch-logs  ^>=1.6.0
+    , base
+    , base-compat-batteries
+    , bytestring
+    , lens
     , log-base
     , stm
-    , bytestring
     , text
-    , lens
     , time
     , transformers
-
-  exposed-modules:
-      Log.Backend.CloudWatchLogs
-  default-language: Haskell2010
+  exposed-modules:    Log.Backend.CloudWatchLogs

--- a/mega-repo-tool/mega-repo-tool.cabal
+++ b/mega-repo-tool/mega-repo-tool.cabal
@@ -1,29 +1,26 @@
-cabal-version:  2.2
-name:           mega-repo-tool
-version:        0
-
-synopsis:       Various commands to manage futurice/haskell-mega-repo
-description:    Build the package and run @stack exec mega-repo-tool -- -h@
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD-3-Clause
-license-file:   LICENSE
-tested-with:    GHC ==8.4.4
-build-type:     Simple
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               mega-repo-tool
+version:            0
+synopsis:           Various commands to manage futurice/haskell-mega-repo
+description:        @cabal new-run mega-repo-tool --help@
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
   default-extensions:
     DeriveAnyClass
     DeriveDataTypeable
@@ -34,7 +31,6 @@ library
     DerivingStrategies
     GeneralizedNewtypeDeriving
     ScopedTypeVariables
-  ghc-options: -Wall
   build-depends:
     , aeson
     , aeson-compat
@@ -44,12 +40,12 @@ library
     , array
     , async
     , aws-lambda-runtime
-    , base >=4.7   && <4.13
+    , base
     , base-compat
     , base16-bytestring
     , base64-bytestring
     , bytestring
-    , Cabal >= 2.2
+    , Cabal                 ^>=2.2 || ^>=2.4
     , cabal-plan
     , case-insensitive
     , containers
@@ -63,8 +59,8 @@ library
     , http-client
     , http-client-tls
     , lens
-    , machines           >= 0.6.1
-    , machines-directory >= 0.2.1.0
+    , machines              >=0.6.1
+    , machines-directory    >=0.2.1.0
     , microstache
     , optparse-applicative
     , parsec
@@ -87,29 +83,25 @@ library
     build-depends: unix
 
   exposed-modules:
-      Futurice.App.MegaRepoTool
-      Futurice.App.MegaRepoTool.BuildDocker
-      Futurice.App.MegaRepoTool.Config
-      Futurice.App.MegaRepoTool.CopyArtifacts
-      Futurice.App.MegaRepoTool.Estimator
-      Futurice.App.MegaRepoTool.Exec
-      Futurice.App.MegaRepoTool.GenPass
-      Futurice.App.MegaRepoTool.GenKeys
-      Futurice.App.MegaRepoTool.Keys
-      Futurice.App.MegaRepoTool.Lambda
-      Futurice.App.MegaRepoTool.PatternCompleter
-      Futurice.App.MegaRepoTool.StackYaml
-      Futurice.App.MegaRepoTool.Stats
-
-  default-language: Haskell2010
+    Futurice.App.MegaRepoTool
+    Futurice.App.MegaRepoTool.BuildDocker
+    Futurice.App.MegaRepoTool.Config
+    Futurice.App.MegaRepoTool.CopyArtifacts
+    Futurice.App.MegaRepoTool.Estimator
+    Futurice.App.MegaRepoTool.Exec
+    Futurice.App.MegaRepoTool.GenKeys
+    Futurice.App.MegaRepoTool.GenPass
+    Futurice.App.MegaRepoTool.Keys
+    Futurice.App.MegaRepoTool.Lambda
+    Futurice.App.MegaRepoTool.PatternCompleter
+    Futurice.App.MegaRepoTool.StackYaml
+    Futurice.App.MegaRepoTool.Stats
 
 executable mega-repo-tool
-  main-is: Main.hs
-  hs-source-dirs:
-      cli
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall -threaded -rtsopts "-with-rtsopts=-N -T"
-  build-depends:
-      base
-    , mega-repo-tool
   default-language: Haskell2010
+  main-is:          Main.hs
+  hs-source-dirs:   cli
+  ghc-options:      -Wall -threaded -rtsopts "-with-rtsopts=-N -T"
+  build-depends:
+    , base
+    , mega-repo-tool

--- a/monad-memoize/monad-memoize.cabal
+++ b/monad-memoize/monad-memoize.cabal
@@ -1,16 +1,14 @@
 cabal-version: 2.2
-name: monad-memoize
-version: 0
-
-synopsis: Monad which can memoize
-category: Control.
-description: 
-  memoize :: m a -> m (m a)
+name:          monad-memoize
+version:       0
+synopsis:      Monad which can memoize
+category:      Control.
+description:   memoize :: m a -> m (m a)
 
 library
-  default-language: Haskell2010
-  ghc-options:      -Wall
-  hs-source-dirs:   src
+  default-language:   Haskell2010
+  ghc-options:        -Wall
+  hs-source-dirs:     src
   default-extensions:
     DeriveAnyClass
     DeriveDataTypeable
@@ -27,5 +25,4 @@ library
     , hashable
     , haxl
     , transformers
-  exposed-modules:
-    Control.Monad.Memoize
+  exposed-modules:    Control.Monad.Memoize

--- a/optparse-sop/optparse-sop.cabal
+++ b/optparse-sop/optparse-sop.cabal
@@ -1,38 +1,36 @@
-name:                optparse-sop
-version:             0
-synopsis:            Very quick generic options-applicative
-description:        
+cabal-version: 2.2
+name:          optparse-sop
+version:       0
+synopsis:      Very quick generic options-applicative
+description:
   For very quick command based clients
   .
   @
   data Cmd = CmdFoo | CmdBar Int
   deriveGeneric ''Cmd
-
   main :: IO ()
   main = execParser opts >>= runCmd
-    where
-      opts = info (helper <*> sopCommandParser) mempty
+  where
+  opts = info (helper <*> sopCommandParser) mempty
   @
-homepage:            https://github.com/futurice/haskell-mega-repo
-bug-reports:         https://github.com/futurice/haskell-mega-repo/issues
-license:             BSD3
-license-file:        LICENSE
-author:              Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:          Oleg Grenrus <oleg.grenrus@iki.fi>
-copyright:           (c) 2017 Futurice
-category:            System
-build-type:          Simple
-cabal-version:       >=1.10
+homepage:      https://github.com/futurice/haskell-mega-repo
+bug-reports:   https://github.com/futurice/haskell-mega-repo/issues
+license:       BSD-3-Clause
+license-file:  LICENSE
+author:        Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:    Oleg Grenrus <oleg.grenrus@iki.fi>
+copyright:     (c) 2017 Futurice
+category:      System
+build-type:    Simple
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  default-language:    Haskell2010
-  hs-source-dirs:      src
-  exposed-modules:
-    Options.SOP
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  exposed-modules:    Options.SOP
   default-extensions:
     DeriveDataTypeable
     DeriveFoldable
@@ -41,14 +39,14 @@ library
     DeriveTraversable
     ScopedTypeVariables
   build-depends:
-    base >=4.8 && <4.13,
-    ansi-pretty,
-    futurice-prelude,
-    generics-sop,
-    generics-sop-lens,
-    intervals,
-    lens,
-    optparse-applicative >= 0.13.0.0 && <0.15,
-    split,
-    time-parsers,
-    trifecta
+    , ansi-pretty
+    , base
+    , futurice-prelude
+    , generics-sop
+    , generics-sop-lens
+    , intervals
+    , lens
+    , optparse-applicative
+    , split
+    , time-parsers
+    , trifecta

--- a/periocron/periocron.cabal
+++ b/periocron/periocron.cabal
@@ -1,34 +1,36 @@
-cabal-version:  2.2
-name:           periocron
-version:        0
-
-synopsis:       Periodical cron
-description:    ...
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD-3-Clause
-license-file:   LICENSE
-tested-with:    GHC==7.8.4, GHC==7.10.3, GHC==8.0.1
-build-type:     Simple
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               periocron
+version:            0
+synopsis:           Periodical cron
+description:        ...
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
+  default-extensions:
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ScopedTypeVariables
   build-depends:
-    , base
     , async
+    , base
     , base-compat
     , clock
     , futurice-metrics
@@ -41,6 +43,4 @@ library
     , text
     , time
     , transformers
-  exposed-modules:
-      Futurice.Periocron
-  default-language: Haskell2010
+  exposed-modules:    Futurice.Periocron

--- a/personio-client/personio-client.cabal
+++ b/personio-client/personio-client.cabal
@@ -1,35 +1,33 @@
-name:           personio-client
-version:        0
-synopsis:       Personio client library
-description:    Bindings to <https://www.personio.de/de/api-documentation/>
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.10.3, GHC==8.0.2
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               personio-client
+version:            0
+synopsis:           Personio client library
+description:        Bindings to <https://www.personio.de/de/api-documentation/>
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
   default-extensions:
     DeriveAnyClass
     DeriveGeneric
     DerivingStrategies
     GeneralizedNewtypeDeriving
-  hs-source-dirs: src
-  ghc-options: -Wall
   build-depends:
-      aeson
+    , aeson
     , aeson-compat
     , base
     , cassava
@@ -43,8 +41,8 @@ library
     , futurice-tribes
     , github
     , http-api-data
-    , intervals
     , http-client
+    , intervals
     , lens
     , lucid
     , monad-http
@@ -58,42 +56,42 @@ library
     , time
     , unordered-containers
   exposed-modules:
-      Control.Monad.Personio
-      Personio
-      Personio.Eval
-      Personio.Request
-      Personio.Types
-      Personio.Types.Cfg
-      Personio.Types.ContractType
-      Personio.Types.Employee
-      Personio.Types.EmployeeId
-      Personio.Types.EmploymentType
-      Personio.Types.Envelope
-      Personio.Types.PersonalIdValidations
-      Personio.Types.SalaryType
-      Personio.Types.ScheduleEmployee
-      Personio.Types.SimpleEmployee
-      Personio.Types.Status
-      Personio.Types.Validation
+    Control.Monad.Personio
+    Personio
+    Personio.Eval
+    Personio.Request
+    Personio.Types
+    Personio.Types.Cfg
+    Personio.Types.ContractType
+    Personio.Types.Employee
+    Personio.Types.EmployeeId
+    Personio.Types.EmploymentType
+    Personio.Types.Envelope
+    Personio.Types.PersonalIdValidations
+    Personio.Types.SalaryType
+    Personio.Types.ScheduleEmployee
+    Personio.Types.SimpleEmployee
+    Personio.Types.Status
+    Personio.Types.Validation
   other-modules:
-      Personio.Types.Internal
-      Personio.Internal.Attribute
-  default-language: Haskell2010
+    Personio.Internal.Attribute
+    Personio.Types.Internal
 
 test-suite unit-tests
-  type: exitcode-stdio-1.0
-  main-is: Tests.hs
-  hs-source-dirs:
-      tests/
-  ghc-options: -Wall
+  default-language: Haskell2010
+  type:             exitcode-stdio-1.0
+  main-is:          Tests.hs
+  hs-source-dirs:   tests/
+  ghc-options:      -Wall
   build-depends:
-      aeson
+    , aeson
     , aeson-compat
     , base
     , cassava
     , constraints
     , containers
     , env-config
+    , file-embed
     , flowdock-rest
     , fum-types
     , futurice-constants
@@ -103,20 +101,18 @@ test-suite unit-tests
     , http-api-data
     , http-client
     , lens
+    , lens-aeson
     , lucid
     , monad-http
     , mtl
+    , personio-client
     , regex-applicative
     , regex-applicative-text
     , scientific
     , swagger2
-    , text
-    , time
-    , unordered-containers
-    , file-embed
-    , lens-aeson
-    , personio-client
     , tasty
     , tasty-hunit
     , tasty-quickcheck
-  default-language: Haskell2010
+    , text
+    , time
+    , unordered-containers

--- a/personio-proxy/personio-proxy.cabal
+++ b/personio-proxy/personio-proxy.cabal
@@ -1,35 +1,38 @@
-name:           personio-proxy
-version:        0
-synopsis:       Personio proxy
-description:    New and fancy
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.8.4, GHC==7.10.3, GHC==8.0.1
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-  personio-proxy.js
+cabal-version:      2.2
+name:               personio-proxy
+version:            0
+synopsis:           Personio proxy
+description:        New and fancy
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: personio-proxy.js
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall
+  default-language:   Haskell2010
+  ghc-options:        -Wall -freduction-depth=30
+  hs-source-dirs:     src
+  default-extensions:
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ScopedTypeVariables
   build-depends:
-      base
     , adjunctions
     , aeson
     , async
+    , base
     , Chart
     , containers
     , deepseq
@@ -44,6 +47,7 @@ library
     , futurice-prelude
     , futurice-servant
     , futurice-tribes
+    , ghc-compact          >=0.1.0.0
     , github
     , lens
     , lens-aeson
@@ -59,30 +63,20 @@ library
     , time
 
   -- Move Futurice.Daily to futurice-prelude
-  build-depends:
-    futurice-integrations
-
-  if impl(ghc >= 8.4.4)
-    build-depends: ghc-compact >= 0.1.0.0
-
-  ghc-options: -freduction-depth=30
+  build-depends:      futurice-integrations
   exposed-modules:
-      Futurice.App.PersonioProxy
-      Futurice.App.PersonioProxy.API
-      Futurice.App.PersonioProxy.Config
-      Futurice.App.PersonioProxy.IndexPage
-      Futurice.App.PersonioProxy.Logic
-      Futurice.App.PersonioProxy.Types
-  default-language: Haskell2010
+    Futurice.App.PersonioProxy
+    Futurice.App.PersonioProxy.API
+    Futurice.App.PersonioProxy.Config
+    Futurice.App.PersonioProxy.IndexPage
+    Futurice.App.PersonioProxy.Logic
+    Futurice.App.PersonioProxy.Types
 
 executable personio-proxy-server
-  main-is: Main.hs
-  hs-source-dirs:
-      srv
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall -threaded -rtsopts
-  build-depends:
-      base >=4.7   && <4.13
-    , personio-proxy
-  ghc-options: -freduction-depth=30
   default-language: Haskell2010
+  main-is:          Main.hs
+  hs-source-dirs:   srv
+  ghc-options:      -Wall -threaded -rtsopts
+  build-depends:
+    , base
+    , personio-proxy

--- a/planmill-client/planmill-client.cabal
+++ b/planmill-client/planmill-client.cabal
@@ -1,40 +1,37 @@
-name:           planmill-client
-version:        0
-synopsis:       PlanMill API
-description:    Bindings to <https://online.planmill.com/pmtrial/schemas/v1_5/index.html PlanMill API 1.5>.
-category:       Web
-homepage:       https://github.com/futurice/haskell-planmill-client#readme
-bug-reports:    https://github.com/futurice/haskell-planmill-client/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.8.4, GHC==7.10.2
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               planmill-client
+version:            0
+synopsis:           PlanMill API
+description:
+  Bindings to <https://online.planmill.com/pmtrial/schemas/v1_5/index.html PlanMill API 1.5>.
+category:           Web
+homepage:           https://github.com/futurice/haskell-planmill-client#readme
+bug-reports:        https://github.com/futurice/haskell-planmill-client/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-planmill-client
 
 library
-  default-language: Haskell2010
-  hs-source-dirs: src
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall -freduction-depth=100
   default-extensions:
     DeriveAnyClass
-    DerivingStrategies
     DeriveDataTypeable
     DeriveFoldable
     DeriveFunctor
     DeriveGeneric
     DeriveTraversable
+    DerivingStrategies
     ScopedTypeVariables
-  ghc-options: -Wall
   build-depends:
-      base
     , aeson
     , aeson-compat
     , aeson-extra
@@ -42,6 +39,7 @@ library
     , ansi-wl-pprint
     , async
     , attoparsec
+    , base
     , base-compat
     , base64-bytestring
     , binary
@@ -79,17 +77,17 @@ library
     , monad-http
     , monad-memoize
     , monad-time
-    , monadcryptorandom >=0.7.0
+    , monadcryptorandom       >=0.7.0
     , mtl
     , operational
     , optparse-sop
     , postgresql-simple
     , QuickCheck
-    , reflection >= 2 && <2.3
+    , reflection              >=2
     , regex-applicative-text
     , scientific
     , semigroups
-    , singleton-bool >= 0.1.2.0
+    , singleton-bool          >=0.1.2.0
     , stm
     , swagger2
     , text
@@ -100,62 +98,57 @@ library
     , unordered-containers
     , vector
     , zlib
-  if impl(ghc >= 8.0)
-    ghc-options: -freduction-depth=100
-  if impl(ghc < 8.0)
-    ghc-options: -fcontext-stack=40
   exposed-modules:
-      Control.Monad.PlanMill
-      PlanMill
-      PlanMill.Auth
-      PlanMill.Classes
-      PlanMill.Endpoints
-      PlanMill.Enumerations
-      PlanMill.Eval
-      PlanMill.Internal.Prelude
-      PlanMill.Queries
-      PlanMill.Queries.Haxl
-      PlanMill.Test
-      PlanMill.Types
-      PlanMill.Types.Absence
-      PlanMill.Types.Account
-      PlanMill.Types.Action
-      PlanMill.Types.Assignment
-      PlanMill.Types.Auth
-      PlanMill.Types.CapacityCalendar
-      PlanMill.Types.Cfg
-      PlanMill.Types.Contact
-      PlanMill.Types.Enumeration
-      PlanMill.Types.Error
-      PlanMill.Types.ExitCriteria
-      PlanMill.Types.Hook
-      PlanMill.Types.Identifier
-      PlanMill.Types.Inserted
-      PlanMill.Types.Me
-      PlanMill.Types.Meta
-      PlanMill.Types.Project
-      PlanMill.Types.Query
-      PlanMill.Types.ReportableAssignment
-      PlanMill.Types.Request
-      PlanMill.Types.ResultInterval
-      PlanMill.Types.ResultOrder
-      PlanMill.Types.Task
-      PlanMill.Types.TimeBalance
-      PlanMill.Types.Timereport
-      PlanMill.Types.UOffset
-      PlanMill.Types.UrlPart
-      PlanMill.Types.User
-      PlanMill.Types.UserCapacity
-      PlanMill.Types.Vacation
-      PlanMill.Worker
+    Control.Monad.PlanMill
+    PlanMill
+    PlanMill.Auth
+    PlanMill.Classes
+    PlanMill.Endpoints
+    PlanMill.Enumerations
+    PlanMill.Eval
+    PlanMill.Internal.Prelude
+    PlanMill.Queries
+    PlanMill.Queries.Haxl
+    PlanMill.Test
+    PlanMill.Types
+    PlanMill.Types.Absence
+    PlanMill.Types.Account
+    PlanMill.Types.Action
+    PlanMill.Types.Assignment
+    PlanMill.Types.Auth
+    PlanMill.Types.CapacityCalendar
+    PlanMill.Types.Cfg
+    PlanMill.Types.Contact
+    PlanMill.Types.Enumeration
+    PlanMill.Types.Error
+    PlanMill.Types.ExitCriteria
+    PlanMill.Types.Hook
+    PlanMill.Types.Identifier
+    PlanMill.Types.Inserted
+    PlanMill.Types.Me
+    PlanMill.Types.Meta
+    PlanMill.Types.Project
+    PlanMill.Types.Query
+    PlanMill.Types.ReportableAssignment
+    PlanMill.Types.Request
+    PlanMill.Types.ResultInterval
+    PlanMill.Types.ResultOrder
+    PlanMill.Types.Task
+    PlanMill.Types.TimeBalance
+    PlanMill.Types.Timereport
+    PlanMill.Types.UOffset
+    PlanMill.Types.UrlPart
+    PlanMill.Types.User
+    PlanMill.Types.UserCapacity
+    PlanMill.Types.Vacation
+    PlanMill.Worker
 
 executable planmill-client
-  main-is: Main.hs
-  hs-source-dirs:
-      cli
-  ghc-options: -Wall
+  default-language: Haskell2010
+  ghc-options:      -Wall -freduction-depth=100
+  main-is:          Main.hs
+  hs-source-dirs:   cli
   build-depends:
-      base >=4.8 && <4.13
     , aeson
     , aeson-compat
     , aeson-extra
@@ -163,6 +156,7 @@ executable planmill-client
     , ansi-wl-pprint
     , async
     , attoparsec
+    , base
     , base-compat
     , base64-bytestring
     , binary
@@ -198,17 +192,20 @@ executable planmill-client
     , lucid
     , monad-http
     , monad-time
-    , monadcryptorandom >=0.7.0
+    , monadcryptorandom       >=0.7.0
     , mtl
     , operational
+    , optparse-applicative
     , optparse-sop
+    , planmill-client
     , postgresql-simple
     , QuickCheck
-    , reflection >= 2 && <2.3
+    , reflection              >=2
     , regex-applicative-text
     , scientific
     , semigroups
-    , singleton-bool >= 0.1.2.0
+    , SHA
+    , singleton-bool          >=0.1.2.0
     , stm
     , swagger2
     , text
@@ -218,27 +215,18 @@ executable planmill-client
     , transformers
     , unordered-containers
     , vector
-    , zlib
-    , planmill-client
-    , optparse-applicative
-    , SHA
     , yaml
-  if impl(ghc >= 8.0)
-    ghc-options: -freduction-depth=100
-  if impl(ghc < 8.0)
-    ghc-options: -fcontext-stack=40
+    , zlib
   other-modules:
-      Caching
-      MonadPretty
-  default-language: Haskell2010
+    Caching
+    MonadPretty
 
 executable pm-cli
-  main-is: Main.hs
-  hs-source-dirs:
-      cli2
-  ghc-options: -Wall -rtsopts -threaded
+  default-language: Haskell2010
+  main-is:          Main.hs
+  hs-source-dirs:   cli2
+  ghc-options:      -Wall -rtsopts -threaded -freduction-depth=100
   build-depends:
-      base >=4.8 && <4.13
     , aeson
     , aeson-compat
     , aeson-extra
@@ -246,6 +234,7 @@ executable pm-cli
     , ansi-wl-pprint
     , async
     , attoparsec
+    , base
     , base-compat
     , base64-bytestring
     , binary
@@ -277,51 +266,45 @@ executable pm-cli
     , http-types
     , intervals
     , lens
-    , log-base
-    , lucid
-    , monad-http
-    , monad-time
-    , monadcryptorandom >=0.7.0
-    , mtl
-    , operational
-    , optparse-sop
-    , postgresql-simple
-    , QuickCheck
-    , reflection >= 2 && <2.3
-    , regex-applicative-text
-    , scientific
-    , semigroups
-    , singleton-bool >= 0.1.2.0
-    , stm
-    , swagger2
-    , text
-    , time
-    , time-locale-compat
-    , time-parsers
-    , transformers
-    , unordered-containers
-    , vector
-    , zlib
     , lifted-async
     , lifted-base
+    , log-base
+    , lucid
     , monad-control
+    , monad-http
+    , monad-time
+    , monadcryptorandom       >=0.7.0
+    , mtl
+    , operational
+    , optparse-sop
     , planmill-client
+    , postgresql-simple
+    , QuickCheck
+    , reflection
+    , regex-applicative-text
     , resource-pool
+    , scientific
+    , semigroups
+    , singleton-bool          >=0.1.2.0
+    , stm
+    , swagger2
+    , text
+    , time
+    , time-locale-compat
+    , time-parsers
+    , transformers
     , transformers-base
-  if impl(ghc >= 8.0)
-    ghc-options: -freduction-depth=100
-  if impl(ghc < 8.0)
-    ghc-options: -fcontext-stack=40
-  default-language: Haskell2010
+    , unordered-containers
+    , vector
+    , zlib
 
 test-suite integration
-  type: exitcode-stdio-1.0
-  main-is: Integration.hs
-  hs-source-dirs:
-      integration
-  ghc-options: -Wall
+  default-language: Haskell2010
+  type:             exitcode-stdio-1.0
+  main-is:          Integration.hs
+  hs-source-dirs:   integration
+  ghc-options:      -Wall -freduction-depth=100
   build-depends:
-      base >=4.8 && <4.13
     , aeson
     , aeson-compat
     , aeson-extra
@@ -329,6 +312,7 @@ test-suite integration
     , ansi-wl-pprint
     , async
     , attoparsec
+    , base
     , base-compat
     , base64-bytestring
     , binary
@@ -365,17 +349,18 @@ test-suite integration
     , monad-http
     , monad-memoize
     , monad-time
-    , monadcryptorandom >=0.7.0
+    , monadcryptorandom       >=0.7.0
     , mtl
     , operational
     , optparse-sop
+    , planmill-client
     , postgresql-simple
     , QuickCheck
-    , reflection >= 2 && <2.3
+    , reflection              >=2
     , regex-applicative-text
     , scientific
     , semigroups
-    , singleton-bool >= 0.1.2.0
+    , singleton-bool          >=0.1.2.0
     , stm
     , swagger2
     , text
@@ -386,21 +371,14 @@ test-suite integration
     , unordered-containers
     , vector
     , zlib
-    , planmill-client
-  if impl(ghc >= 8.0)
-    ghc-options: -freduction-depth=100
-  if impl(ghc < 8.0)
-    ghc-options: -fcontext-stack=40
-  default-language: Haskell2010
 
 test-suite test
-  type: exitcode-stdio-1.0
-  main-is: Tests.hs
-  hs-source-dirs:
-      test
-  ghc-options: -Wall
+  default-language: Haskell2010
+  type:             exitcode-stdio-1.0
+  main-is:          Tests.hs
+  hs-source-dirs:   test
+  ghc-options:      -Wall
   build-depends:
-      base >=4.8 && <4.13
     , aeson
     , aeson-compat
     , aeson-extra
@@ -408,6 +386,7 @@ test-suite test
     , ansi-wl-pprint
     , async
     , attoparsec
+    , base
     , base-compat
     , base64-bytestring
     , binary
@@ -425,6 +404,7 @@ test-suite test
     , DRBG
     , env-config
     , exceptions
+    , file-embed
     , futurice-constants
     , futurice-metrics
     , futurice-prelude
@@ -444,19 +424,22 @@ test-suite test
     , monad-http
     , monad-memoize
     , monad-time
-    , monadcryptorandom >=0.7.0
+    , monadcryptorandom       >=0.7.0
     , mtl
     , operational
     , optparse-sop
+    , planmill-client
     , postgresql-simple
     , QuickCheck
-    , reflection >= 2 && <2.3
+    , reflection              >=2
     , regex-applicative-text
     , scientific
     , semigroups
-    , singleton-bool >= 0.1.2.0
+    , singleton-bool          >=0.1.2.0
     , stm
     , swagger2
+    , tasty
+    , tasty-quickcheck
     , text
     , time
     , time-locale-compat
@@ -465,12 +448,3 @@ test-suite test
     , unordered-containers
     , vector
     , zlib
-    , planmill-client
-    , tasty
-    , tasty-quickcheck
-    , file-embed
-  if impl(ghc >= 8.0)
-    ghc-options: -freduction-depth=100
-  if impl(ghc < 8.0)
-    ghc-options: -fcontext-stack=40
-  default-language: Haskell2010

--- a/planmill-proxy/planmill-proxy.cabal
+++ b/planmill-proxy/planmill-proxy.cabal
@@ -1,57 +1,59 @@
-cabal-version:  2.2
-name:           planmill-proxy
-version:        0
-
-synopsis:       Planmill proxy
-description:    New and fancy
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD-3-Clause
-license-file:   LICENSE
-build-type:     Simple
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               planmill-proxy
+version:            0
+synopsis:           Planmill proxy
+description:        New and fancy
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall
+  default-language:   Haskell2010
+  ghc-options:        -Wall -freduction-depth=30
+  hs-source-dirs:     src
+  default-extensions:
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ScopedTypeVariables
   build-depends:
-      base
-    , constraints
-    , env-config
-    , futurice-prelude
-    , http-client
-    , http-client-tls
-    , intervals
-    , planmill-client
-    , time-parsers >=0.1.1.0
     , aeson
     , aeson-compat
+    , base
     , binary
     , binary-tagged
     , bytestring
     , Chart
     , colour
+    , constraints
     , containers
     , data-default-class
+    , env-config
     , exceptions
     , futurice-chart
     , futurice-metrics
     , futurice-postgres
+    , futurice-prelude
     , futurice-servant
+    , http-client
+    , http-client-tls
     , intervals
+    , lens
     , monad-logger
     , periocron
+    , planmill-client
     , postgresql-simple
     , postgresql-simple-url
     , resource-pool
@@ -62,11 +64,9 @@ library
     , swagger2
     , text
     , time
+    , time-parsers           >=0.1.1.0
     , unordered-containers
     , vector
-    , lens
-  ghc-options: -freduction-depth=30
-
   exposed-modules:
     Futurice.App.PlanMillProxy
     Futurice.App.PlanMillProxy.API
@@ -77,19 +77,16 @@ library
     Futurice.App.PlanMillProxy.Logic.Common
     Futurice.App.PlanMillProxy.Logic.Timereports
     Futurice.App.PlanMillProxy.Types
-  default-language: Haskell2010
 
 executable planmill-proxy-capacity-lambda
   ghc-options:      -Wall
   hs-source-dirs:   src-capacity lambdas
   main-is:          CapacityLambda.hs
   default-language: Haskell2010
-  other-modules:
-    Futurice.Lambda.PlanMillProxy.Capacity
-
+  other-modules:    Futurice.Lambda.PlanMillProxy.Capacity
   build-depends:
-    , base
     , aeson
+    , base
     , binary-tagged
     , bytestring
     , directory
@@ -106,12 +103,10 @@ executable planmill-proxy-timereports-lambda
   hs-source-dirs:   src-timereports lambdas
   main-is:          TimereportLambda.hs
   default-language: Haskell2010
-  other-modules:
-    Futurice.Lambda.PlanMillProxy.Timereports
-
+  other-modules:    Futurice.Lambda.PlanMillProxy.Timereports
   build-depends:
-    , base
     , aeson
+    , base
     , binary-tagged
     , bytestring
     , containers
@@ -131,12 +126,10 @@ executable planmill-proxy-cache-lambda
   hs-source-dirs:   src-cache lambdas
   main-is:          CacheLambda.hs
   default-language: Haskell2010
-  other-modules:
-    Futurice.Lambda.PlanMillProxy.Cache
-
+  other-modules:    Futurice.Lambda.PlanMillProxy.Cache
   build-depends:
-    , base
     , aeson
+    , base
     , binary-tagged
     , bytestring
     , constraints
@@ -150,11 +143,10 @@ executable planmill-proxy-cache-lambda
     , time
 
 executable planmill-proxy-server
-  main-is: Main.hs
-  hs-source-dirs:
-      srv
-  ghc-options: -Wall -threaded -rtsopts
-  build-depends:
-      base
-    , planmill-proxy
   default-language: Haskell2010
+  main-is:          Main.hs
+  hs-source-dirs:   srv
+  ghc-options:      -Wall -threaded -rtsopts
+  build-depends:
+    , base
+    , planmill-proxy

--- a/planmill-sync/planmill-sync.cabal
+++ b/planmill-sync/planmill-sync.cabal
@@ -1,38 +1,37 @@
--- This file has been generated from package.yaml by hpack version 0.18.1.
---
--- see: https://github.com/sol/hpack
-
-name:           planmill-sync
-version:        0
-synopsis:       Manage PlanMill
-description:    New and fancy
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.10.3
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               planmill-sync
+version:            0
+synopsis:           Manage PlanMill
+description:        New and fancy
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
+  default-extensions:
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ScopedTypeVariables
   build-depends:
-      base                  >=4.7   && <4.13
     , aeson
     , aeson-compat
+    , base
     , clay
     , containers
     , env-config
@@ -60,24 +59,21 @@ library
     , these
     , writer-cps-mtl
   exposed-modules:
-      Futurice.App.PlanMillSync
-      Futurice.App.PlanMillSync.Actions
-      Futurice.App.PlanMillSync.API
-      Futurice.App.PlanMillSync.Config
-      Futurice.App.PlanMillSync.Ctx
-      Futurice.App.PlanMillSync.IndexPage
-      Futurice.App.PlanMillSync.Markup
-      Futurice.App.PlanMillSync.Monad
-      Futurice.App.PlanMillSync.Types
-  default-language: Haskell2010
+    Futurice.App.PlanMillSync
+    Futurice.App.PlanMillSync.API
+    Futurice.App.PlanMillSync.Actions
+    Futurice.App.PlanMillSync.Config
+    Futurice.App.PlanMillSync.Ctx
+    Futurice.App.PlanMillSync.IndexPage
+    Futurice.App.PlanMillSync.Markup
+    Futurice.App.PlanMillSync.Monad
+    Futurice.App.PlanMillSync.Types
 
 executable planmill-sync-server
-  main-is: Main.hs
-  hs-source-dirs:
-      srv
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall -threaded -rtsopts
-  build-depends:
-      base
-    , planmill-sync
   default-language: Haskell2010
+  main-is:          Main.hs
+  hs-source-dirs:   srv
+  ghc-options:      -Wall -threaded -rtsopts
+  build-depends:
+    , base
+    , planmill-sync

--- a/power-client/power-client.cabal
+++ b/power-client/power-client.cabal
@@ -1,15 +1,14 @@
 cabal-version: 2.2
-name: power-client
-version: 0
-
-synopsis: Power client
-category: Integration
-description: Haskell bindings to Power API
+name:          power-client
+version:       0
+synopsis:      Power client
+category:      Integration
+description:   Haskell bindings to Power API
 
 library
-  default-language: Haskell2010
-  ghc-options:      -Wall
-  hs-source-dirs:   src
+  default-language:   Haskell2010
+  ghc-options:        -Wall
+  hs-source-dirs:     src
   default-extensions:
     DeriveAnyClass
     DeriveDataTypeable

--- a/preferences-app/preferences-app.cabal
+++ b/preferences-app/preferences-app.cabal
@@ -1,32 +1,28 @@
-name:           preferences-app
-version:        0
-synopsis:       Preferences
-description:    Single preferences for all apps
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.10.3, GHC==8.0.2
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               preferences-app
+version:            0
+synopsis:           Preferences
+description:        Single preferences for all apps
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  ghc-options: -Wall
+  hs-source-dirs:   src
+  ghc-options:      -Wall
   build-depends:
-      base                  >=4.7   && <4.13
     , aeson
+    , base
     , base-compat
     , bytestring
     , clay
@@ -47,19 +43,18 @@ library
     , text
     , time
   exposed-modules:
-      Futurice.App.Preferences.Config
-      Futurice.App.Preferences.Ctx
-      Futurice.App.Preferences.IndexPage
-      Futurice.App.Preferences.Main
-      Futurice.App.Preferences.Markup
+    Futurice.App.Preferences.Config
+    Futurice.App.Preferences.Ctx
+    Futurice.App.Preferences.IndexPage
+    Futurice.App.Preferences.Main
+    Futurice.App.Preferences.Markup
   default-language: Haskell2010
 
 executable preferences-app-server
-  main-is: Main.hs
-  hs-source-dirs:
-      srv
-  ghc-options: -Wall -threaded -rtsopts
+  main-is:          Main.hs
+  hs-source-dirs:   srv
+  ghc-options:      -Wall -threaded -rtsopts
   build-depends:
-      base
+    , base
     , preferences-app
   default-language: Haskell2010

--- a/preferences-client/preferences-client.cabal
+++ b/preferences-client/preferences-client.cabal
@@ -1,51 +1,47 @@
-cabal-version:  2.2
-name:           preferences-client
-version:        0
-
-synopsis:       Single place for preferences
-description:    Preferences
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD-3-Clause
-license-file:   LICENSE
-build-type:     Simple
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               preferences-client
+version:            0
+synopsis:           Single place for preferences
+description:        Preferences
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
   default-extensions:
     DeriveGeneric
     DerivingStrategies
     GeneralizedNewtypeDeriving
-  ghc-options: -Wall
   build-depends:
-    , base                  >=4.10   && <4.13
     , aeson
+    , base
     , base-compat
     , bytestring
     , env-config
+    , fum-types
     , futurice-prelude
     , futurice-tribes
-    , fum-types
     , http-client
     , http-types
     , lens
-    , servant-server
     , servant-client
+    , servant-server
     , text
     , time
   exposed-modules:
-      Futurice.App.Preferences.API
-      Futurice.App.Preferences.Client
-      Futurice.App.Preferences.Types
-  default-language: Haskell2010
+    Futurice.App.Preferences.API
+    Futurice.App.Preferences.Client
+    Futurice.App.Preferences.Types

--- a/proxy-app/proxy-app.cabal
+++ b/proxy-app/proxy-app.cabal
@@ -1,33 +1,30 @@
-name:           proxy-app
-version:        0
-synopsis:       Proxy app
-description:    Make a proxy of everything
-category:       Web
-homepage:       https://github.com/futurice/proxy-app#readme
-bug-reports:    https://github.com/futurice/proxy-app/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==8.0.2, GHC==8.2.1
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               proxy-app
+version:            0
+synopsis:           Proxy app
+description:        Make a proxy of everything
+category:           Web
+homepage:           https://github.com/futurice/proxy-app#readme
+bug-reports:        https://github.com/futurice/proxy-app/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/proxy-app
 
 library
-  hs-source-dirs:
-      src
-  ghc-options: -Wall
+  default-language: Haskell2010
+  hs-source-dirs:   src
+  ghc-options:      -Wall
   build-depends:
-      base                  >=4.7   && <4.13
     , aeson
     , aeson-compat
+    , base
     , base-compat
     , bifunctors
     , blaze-html
@@ -74,39 +71,36 @@ library
     , unordered-containers
     , vector
     , wai
-    , wai-extra >=3.0.19
+    , wai-extra               >=3.0.19
     , warp
   exposed-modules:
-      Futurice.App.Proxy
-      Futurice.App.Proxy.Config
-      Futurice.App.Proxy.Ctx
-      Futurice.App.Proxy.Markup
-      Servant.Excel
-  default-language: Haskell2010
+    Futurice.App.Proxy
+    Futurice.App.Proxy.Config
+    Futurice.App.Proxy.Ctx
+    Futurice.App.Proxy.Markup
+    Servant.Excel
 
 executable proxy-app-server
-  main-is: Main.hs
-  hs-source-dirs:
-      srv
-  ghc-options: -Wall -threaded -rtsopts
-  build-depends:
-      base
-    , proxy-app
   default-language: Haskell2010
+  main-is:          Main.hs
+  hs-source-dirs:   srv
+  ghc-options:      -Wall -threaded -rtsopts
+  build-depends:
+    , base
+    , proxy-app
 
 test-suite proxy-app-tests
-  type: exitcode-stdio-1.0
-  main-is: Tests.hs
-  hs-source-dirs:
-      tests/
-  ghc-options: -Wall
+  default-language: Haskell2010
+  type:             exitcode-stdio-1.0
+  main-is:          Tests.hs
+  hs-source-dirs:   tests/
+  ghc-options:      -Wall
   build-depends:
-      base
-    , binary-tagged
+    , base
     , base16-bytestring
+    , binary-tagged
     , futurice-github
     , futurice-prelude
     , planmill-client
     , tasty
     , tasty-quickcheck
-  default-language: Haskell2010

--- a/proxy-mgmt-app/proxy-mgmt-app.cabal
+++ b/proxy-mgmt-app/proxy-mgmt-app.cabal
@@ -1,28 +1,25 @@
-name:           proxy-mgmt-app
-version:        0
-synopsis:       Proxy conf management
-description:    Proxy conf management
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-rpo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-rpo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.8.4, GHC==7.10.3, GHC==8.0.1
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               proxy-mgmt-app
+version:            0
+synopsis:           Proxy conf management
+description:        Proxy conf management
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-rpo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-rpo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
-  location: https://github.com/futurice/haskell-mega-rpo
+  type:     git
+  location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
+  default-language:   Haskell2010
+  hs-source-dirs:     src
   default-extensions:
     DeriveAnyClass
     DeriveDataTypeable
@@ -34,9 +31,9 @@ library
     GeneralizedNewtypeDeriving
     ScopedTypeVariables
   build-depends:
-      base                  >=4.7   && <4.13
     , aeson
     , aeson-compat
+    , base
     , base-compat
     , base64-bytestring
     , clay
@@ -70,31 +67,28 @@ library
     , time
     , vector
   exposed-modules:
-      Futurice.App.ProxyMgmt.API
-      Futurice.App.ProxyMgmt.Config
-      Futurice.App.ProxyMgmt.Ctx
-      Futurice.App.ProxyMgmt.Commands.AddEndpoint
-      Futurice.App.ProxyMgmt.Commands.AddToken
-      Futurice.App.ProxyMgmt.Commands.RemoveEndpoint
-      Futurice.App.ProxyMgmt.Commands.RegenerateToken
-      Futurice.App.ProxyMgmt.Dashdo
-      Futurice.App.ProxyMgmt.Main
-      Futurice.App.ProxyMgmt.Markup
-      Futurice.App.ProxyMgmt.Pages.Audit
-      Futurice.App.ProxyMgmt.Pages.Index
-      Futurice.App.ProxyMgmt.Pages.Policies
-      Futurice.App.ProxyMgmt.Pages.Tokens
-      Futurice.App.ProxyMgmt.Types
-      Futurice.App.ProxyMgmt.Utils
-  default-language: Haskell2010
+    Futurice.App.ProxyMgmt.API
+    Futurice.App.ProxyMgmt.Commands.AddEndpoint
+    Futurice.App.ProxyMgmt.Commands.AddToken
+    Futurice.App.ProxyMgmt.Commands.RegenerateToken
+    Futurice.App.ProxyMgmt.Commands.RemoveEndpoint
+    Futurice.App.ProxyMgmt.Config
+    Futurice.App.ProxyMgmt.Ctx
+    Futurice.App.ProxyMgmt.Dashdo
+    Futurice.App.ProxyMgmt.Main
+    Futurice.App.ProxyMgmt.Markup
+    Futurice.App.ProxyMgmt.Pages.Audit
+    Futurice.App.ProxyMgmt.Pages.Index
+    Futurice.App.ProxyMgmt.Pages.Policies
+    Futurice.App.ProxyMgmt.Pages.Tokens
+    Futurice.App.ProxyMgmt.Types
+    Futurice.App.ProxyMgmt.Utils
 
 executable proxy-mgmt-app-server
-  main-is: Main.hs
-  hs-source-dirs:
-      srv
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -threaded -rtsopts
-  build-depends:
-      base
-    , proxy-mgmt-app
   default-language: Haskell2010
+  main-is:          Main.hs
+  hs-source-dirs:   srv
+  ghc-options:      -threaded -rtsopts
+  build-depends:
+    , base
+    , proxy-mgmt-app

--- a/proxy-types/proxy-types.cabal
+++ b/proxy-types/proxy-types.cabal
@@ -1,27 +1,26 @@
-name:           proxy-types
-version:        0
-synopsis:       Prox types
-description:    Prox types.
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               proxy-types
+version:            0
+synopsis:           Prox types
+description:        Prox types.
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall
   default-extensions:
     DeriveAnyClass
     DeriveDataTypeable
@@ -32,10 +31,9 @@ library
     DerivingStrategies
     GeneralizedNewtypeDeriving
     ScopedTypeVariables
-  ghc-options: -Wall
   build-depends:
-      base                  >=4.10   && <4.13
     , avatar-client
+    , base
     , containers
     , fum-api
     , fum-types
@@ -52,9 +50,10 @@ library
     , sms-proxy-client
     , swagger2
     , text
+
   -- Integrations
   build-depends:
-      contacts-api
+    , contacts-api
     , fum-api
     , futurice-github
     , personio-client
@@ -62,6 +61,5 @@ library
     , reports-app
     , servant-binary-tagged
   exposed-modules:
-      Futurice.App.Proxy.API
-      Futurice.App.Proxy.Endpoint
-  default-language: Haskell2010
+    Futurice.App.Proxy.API
+    Futurice.App.Proxy.Endpoint

--- a/reports-app/reports-app.cabal
+++ b/reports-app/reports-app.cabal
@@ -1,29 +1,29 @@
-name:           reports-app
-version:        0
-synopsis:       Show various reports.
-description:    ...
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-build-type:     Simple
-cabal-version:  >= 1.10
-
+cabal-version:      2.2
+name:               reports-app
+version:            0
+synopsis:           Show various reports.
+description:        ...
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
 extra-source-files:
   i-dont-know.json
   missing-hours-email.template
   missing-hours-sms.template
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
+  default-language:   Haskell2010
+  hs-source-dirs:     src
+  ghc-options:        -Wall -fprint-potential-instances
   default-extensions:
     DeriveAnyClass
     DeriveDataTypeable
@@ -35,15 +35,14 @@ library
     GeneralizedNewtypeDeriving
     InstanceSigs
     ScopedTypeVariables
-  ghc-options: -Wall -fprint-potential-instances
   build-depends:
-      base >= 4.8 && <4.13
-    , base-compat
     , adjunctions
     , aeson
     , aeson-pretty
     , algebraic-graphs
     , ansi-pretty
+    , base
+    , base-compat
     , base64-bytestring
     , bifunctors
     , binary-orphans
@@ -80,10 +79,10 @@ library
     , futurice-servant
     , futurice-tribes
     , generics-sop
-    , github >=0.15.0
-    , hashable >= 1.2
+    , github                    >=0.15.0
+    , hashable                  >=1.2
     , http-api-data
-    , http-client >= 0.5
+    , http-client               >=0.5
     , http-client-tls
     , http-types
     , intervals
@@ -131,39 +130,39 @@ library
     , vector
     , wai
   exposed-modules:
-      Futurice.App.Reports
-      Futurice.App.Reports.API
-      Futurice.App.Reports.ActiveAccounts
-      Futurice.App.Reports.CareerLengthChart
-      Futurice.App.Reports.Config
-      Futurice.App.Reports.Ctx
-      Futurice.App.Reports.Dashdo
-      Futurice.App.Reports.GithubReposDashdo
-      Futurice.App.Reports.IDontKnow
-      Futurice.App.Reports.Inventory
-      Futurice.App.Reports.Markup
-      Futurice.App.Reports.MissingHours
-      Futurice.App.Reports.MissingHoursChart
-      Futurice.App.Reports.MissingHoursDailyChart
-      Futurice.App.Reports.MissingHoursDashdo
-      Futurice.App.Reports.MissingHoursNotifications
-      Futurice.App.Reports.OfficeVibeIntegration
-      Futurice.App.Reports.PlanMillAccountValidation
-      Futurice.App.Reports.PowerAbsences
-      Futurice.App.Reports.PowerProjects
-      Futurice.App.Reports.PowerUser
-      Futurice.App.Reports.ProjectHours
-      Futurice.App.Reports.SupervisorsGraph
-      Futurice.App.Reports.Templates
-      Futurice.App.Reports.TimereportsByTask
-      Futurice.App.Reports.TimereportsDump
-      Futurice.App.Reports.UtzChart
-  default-language: Haskell2010
+    Futurice.App.Reports
+    Futurice.App.Reports.API
+    Futurice.App.Reports.ActiveAccounts
+    Futurice.App.Reports.CareerLengthChart
+    Futurice.App.Reports.Config
+    Futurice.App.Reports.Ctx
+    Futurice.App.Reports.Dashdo
+    Futurice.App.Reports.GithubReposDashdo
+    Futurice.App.Reports.IDontKnow
+    Futurice.App.Reports.Inventory
+    Futurice.App.Reports.Markup
+    Futurice.App.Reports.MissingHours
+    Futurice.App.Reports.MissingHoursChart
+    Futurice.App.Reports.MissingHoursDailyChart
+    Futurice.App.Reports.MissingHoursDashdo
+    Futurice.App.Reports.MissingHoursNotifications
+    Futurice.App.Reports.OfficeVibeIntegration
+    Futurice.App.Reports.PlanMillAccountValidation
+    Futurice.App.Reports.PowerAbsences
+    Futurice.App.Reports.PowerProjects
+    Futurice.App.Reports.PowerUser
+    Futurice.App.Reports.ProjectHours
+    Futurice.App.Reports.SupervisorsGraph
+    Futurice.App.Reports.Templates
+    Futurice.App.Reports.TimereportsByTask
+    Futurice.App.Reports.TimereportsDump
+    Futurice.App.Reports.UtzChart
 
 executable reports-app-server
-  main-is: Main.hs
-  hs-source-dirs:
-      srv
-  ghc-options: -Wall -Wall -threaded -rtsopts
-  build-depends: base, reports-app
   default-language: Haskell2010
+  main-is:          Main.hs
+  hs-source-dirs:   srv
+  ghc-options:      -Wall -Wall -threaded -rtsopts
+  build-depends:
+    , base
+    , reports-app

--- a/servant-Chart/servant-Chart.cabal
+++ b/servant-Chart/servant-Chart.cabal
@@ -1,32 +1,28 @@
-cabal-version:  2.2
-name:           servant-Chart
-version:        0
-
-synopsis:       Servant support for Chart
-description:    Servant support for Chart
-category:       Web
-homepage:       https://github.com/phadej/servant-Chart-svg#readme
-bug-reports:    https://github.com/phadej/servant-Chart-svg/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD-3-Clause
-license-file:   LICENSE
-tested-with:    GHC==7.8.4, GHC==7.10.3, GHC==8.0.2
-build-type:     Simple
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               servant-Chart
+version:            0
+synopsis:           Servant support for Chart
+description:        Servant support for Chart
+category:           Web
+homepage:           https://github.com/phadej/servant-Chart-svg#readme
+bug-reports:        https://github.com/phadej/servant-Chart-svg/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+tested-with:        ghc ==7.8.4 ghc ==7.10.3 ghc ==8.0.2
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/phadej/servant-Chart-svg
 
 library
-  hs-source-dirs:
-      src
-  ghc-options: -Wall
+  hs-source-dirs:   src
+  ghc-options:      -Wall
   build-depends:
-      base           >=4.7      && <4.13
+    , base             >=4.7 && <4.13
     , Chart
     , Chart-diagrams
     , deepseq
@@ -34,18 +30,19 @@ library
     , diagrams-svg
     , file-embed
     , file-embed-lzma
-    , http-media     >=0.6.2
-    , servant        >=0.4.4.5  && <0.16
+    , http-media       >=0.6.2
+    , servant          >=0.4.4.5 && <0.16
     , svg-builder
     , SVGFonts
     , swagger2
     , vector
   build-depends:
-    adjunctions, futurice-prelude, mtl
+    , adjunctions
+    , futurice-prelude
+    , mtl
 
-  if impl(ghc >= 8.4.4)
+  if impl(ghc >=8.4.4)
     build-depends: ghc-compact ^>=0.1.0.0
 
-  exposed-modules:
-      Servant.Chart
+  exposed-modules:  Servant.Chart
   default-language: Haskell2010

--- a/servant-algebraic-graphs/servant-algebraic-graphs.cabal
+++ b/servant-algebraic-graphs/servant-algebraic-graphs.cabal
@@ -1,41 +1,36 @@
-cabal-version:  2.0
-name:           servant-algebraic-graphs
-version:        0
-
-synopsis:       Servant support for algebraic-graphs
-description:    Servant support for algebraic-graphs, uses graphviz to render them.
-category:       Web
-homepage:       https://github.com/phadej/servant-algebraic-graphs#readme
-bug-reports:    https://github.com/phadej/servant-algebraic-graphs/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==8.0.2, GHC==8.2.1
-build-type:     Simple
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               servant-algebraic-graphs
+version:            0
+synopsis:           Servant support for algebraic-graphs
+description:
+  Servant support for algebraic-graphs, uses graphviz to render them.
+category:           Web
+homepage:           https://github.com/phadej/servant-algebraic-graphs#readme
+bug-reports:        https://github.com/phadej/servant-algebraic-graphs/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+tested-with:        ghc ==8.0.2 ghc ==8.2.1
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/phadej/servant-algebraic-graphs
 
 library
-  hs-source-dirs:
-      src
-  ghc-options: -Wall
+  hs-source-dirs:   src
+  ghc-options:      -Wall
   build-depends:
-      algebraic-graphs ^>= 0.2
-
-    , base           >=4.9   && <4.13
+    , algebraic-graphs  ^>=0.2
+    , base              >=4.9 && <4.13
     , bytestring
     , deepseq
-    , http-media     >=0.6.2
+    , http-media        >=0.6.2
     , process-extras
-    , servant        >=0.12  && <0.16
+    , servant           >=0.12 && <0.16
     , swagger2
     , text
-  exposed-modules:
-      Servant.Graph
+  exposed-modules:  Servant.Graph
   default-language: Haskell2010

--- a/servant-binary-tagged/servant-binary-tagged.cabal
+++ b/servant-binary-tagged/servant-binary-tagged.cabal
@@ -1,41 +1,33 @@
--- This file has been generated from package.yaml by hpack version 0.18.1.
---
--- see: https://github.com/sol/hpack
-
-name:           servant-binary-tagged
-version:        0
-synopsis:       Servant support for binary-tagged
-description:    Servant support for binary-tagged
-category:       Web
-homepage:       https://github.com/phadej/servant-yaml#readme
-bug-reports:    https://github.com/phadej/servant-yaml/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.8.4, GHC==7.10.3, GHC==8.0.1
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               servant-binary-tagged
+version:            0
+synopsis:           Servant support for binary-tagged
+description:        Servant support for binary-tagged
+category:           Web
+homepage:           https://github.com/phadej/servant-yaml#readme
+bug-reports:        https://github.com/phadej/servant-yaml/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+tested-with:        ghc ==7.8.4 ghc ==7.10.3 ghc ==8.0.1
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/phadej/servant-yaml
 
 library
-  hs-source-dirs:
-      src
-  ghc-options: -Wall
+  hs-source-dirs:   src
+  ghc-options:      -Wall
   build-depends:
-      base          >=4.7      && <4.13
+    , base           >=4.7 && <4.13
     , binary
-    , binary-tagged >=0.1      && <0.2
-    , bytestring    >=0.10.4.0 && <0.11
-    , http-media    >=0.6.2
-    , servant       >=0.4.4.5  && <0.16
-    , zlib          >=0.6      && <0.7
-  exposed-modules:
-      Servant.Binary.Tagged
+    , binary-tagged  ^>=0.1
+    , bytestring     ^>=0.10.4.0
+    , http-media     >=0.6.2
+    , servant        >=0.4.4.5 && <0.16
+    , zlib           ^>=0.6
+  exposed-modules:  Servant.Binary.Tagged
   default-language: Haskell2010

--- a/servant-cached/servant-cached.cabal
+++ b/servant-cached/servant-cached.cabal
@@ -1,15 +1,14 @@
-cabal-version:  2.2
-name:           servant-cached
-version:        0
-synopsis:       Servant Cached
-description:    Servant Cached
-category:       Web
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD-3-Clause
-license-file:   LICENSE
-tested-with:    GHC==7.8.4, GHC==7.10.3, GHC==8.0.2
-build-type:     Simple
+cabal-version: 2.2
+name:          servant-cached
+version:       0
+synopsis:      Servant Cached
+description:   Servant Cached
+category:      Web
+author:        Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:    Oleg Grenrus <oleg.grenrus@iki.fi>
+license:       BSD-3-Clause
+license-file:  LICENSE
+build-type:    Simple
 
 library
   default-language: Haskell2010
@@ -21,5 +20,4 @@ library
     , futurice-prelude
     , servant
     , swagger2
-  exposed-modules:
-      Servant.Cached
+  exposed-modules:  Servant.Cached

--- a/servant-dashdo/servant-dashdo.cabal
+++ b/servant-dashdo/servant-dashdo.cabal
@@ -1,44 +1,41 @@
-name:           servant-dashdo
-version:        0
-synopsis:       Servant support for dashdo
-description:    Servant support for dashdo
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==8.0.2, GHC==8.2.1
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               servant-dashdo
+version:            0
+synopsis:           Servant support for dashdo
+description:        Servant support for dashdo
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+tested-with:        ghc ==8.0.2 ghc ==8.2.1
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  exposed-modules:
-    Dashdo.Servant
+  exposed-modules:  Dashdo.Servant
   build-depends:
-    base            >=4.9     && <4.13,
-    dashdo,
-    bytestring,
-    containers,
-    http-api-data   >=0.3.7.1 && <0.5,
-    http-media      >=0.6.2,
-    lucid           >=2.9.9   && <2.10,
-    random          >=1.1     && <1.2,
-    safe-exceptions >=0.1.6.0 && <0.2,
-    servant-lucid   >=0.7.1   && <0.9,
-    servant-server  >=0.11    && <0.16,
-    text,
-    transformers,
-    uuid-types      >=1.0.3   && <1.1,
-    wai             >=3.2.1.1 && <3.3
+    , base             >=4.9 && <4.13
+    , bytestring
+    , containers
+    , dashdo
+    , http-api-data    >=0.3.7.1 && <0.5
+    , http-media       >=0.6.2
+    , lucid            ^>=2.9.9
+    , random           ^>=1.1
+    , safe-exceptions  ^>=0.1.6.0
+    , servant-lucid    >=0.7.1 && <0.9
+    , servant-server   >=0.11 && <0.16
+    , text
+    , transformers
+    , uuid-types       ^>=1.0.3
+    , wai              ^>=3.2.1.1
   default-language: Haskell2010
   hs-source-dirs:   src
   ghc-options:      -Wall

--- a/sisosota-app/sisosota-app.cabal
+++ b/sisosota-app/sisosota-app.cabal
@@ -1,29 +1,25 @@
-cabal-version:  2.0
-name:           sisosota-app
-version:        0
-
-synopsis:       Simple CAS
-description:    Simple CAS
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-rpo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-rpo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-build-type:     Simple
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               sisosota-app
+version:            0
+synopsis:           Simple CAS
+description:        Simple CAS
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-rpo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-rpo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
-  location: https://github.com/futurice/haskell-mega-rpo
+  type:     git
+  location: https://github.com/futurice/haskell-mega-repo
 
 library
-  ghc-options: -Wall
-  hs-source-dirs:
-      src
+  ghc-options:        -Wall
+  hs-source-dirs:     src
   default-extensions:
     DeriveDataTypeable
     DeriveFoldable
@@ -32,14 +28,14 @@ library
     DeriveTraversable
     ScopedTypeVariables
   build-depends:
-      base                  >=4.7   && <4.13
     , aeson
     , aeson-compat
     , amazonka
     , amazonka-s3
-    , bytestring
+    , base
     , base-compat
     , base64-bytestring
+    , bytestring
     , clay
     , containers
     , entropy
@@ -70,19 +66,18 @@ library
     , time
     , vector
   exposed-modules:
-      Futurice.App.Sisosota.Config
-      Futurice.App.Sisosota.Ctx
-      Futurice.App.Sisosota.IndexPage
-      Futurice.App.Sisosota.Main
-      Futurice.App.Sisosota.Markup
-  default-language: Haskell2010
+    Futurice.App.Sisosota.Config
+    Futurice.App.Sisosota.Ctx
+    Futurice.App.Sisosota.IndexPage
+    Futurice.App.Sisosota.Main
+    Futurice.App.Sisosota.Markup
+  default-language:   Haskell2010
 
 executable sisosota-app-server
-  main-is: Main.hs
-  hs-source-dirs:
-      srv
-  ghc-options: -threaded -rtsopts
+  main-is:          Main.hs
+  hs-source-dirs:   srv
+  ghc-options:      -threaded -rtsopts
   build-depends:
-      base
+    , base
     , sisosota-app
   default-language: Haskell2010

--- a/sisosota-client/sisosota-client.cabal
+++ b/sisosota-client/sisosota-client.cabal
@@ -1,29 +1,26 @@
-cabal-version:  2.0
-name:           sisosota-client
-version:        0
-
-synopsis:       Simple CAS
-description:    Simple CAS
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-rpo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-rpo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-build-type:     Simple
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               sisosota-client
+version:            0
+synopsis:           Simple CAS
+description:        Simple CAS
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-rpo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-rpo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-rpo
 
 library
-  ghc-options: -Wall
-  hs-source-dirs:
-      src
+  default-language:   Haskell2010
+  ghc-options:        -Wall
+  hs-source-dirs:     src
   default-extensions:
     DeriveDataTypeable
     DeriveFoldable
@@ -34,10 +31,10 @@ library
     GeneralizedNewtypeDeriving
     ScopedTypeVariables
   build-depends:
-      base                  >=4.7   && <4.13
     , aeson
     , amazonka
     , amazonka-s3
+    , base
     , base64-bytestring
     , bytestring
     , conduit-extra
@@ -52,8 +49,7 @@ library
     , swagger2
     , unordered-containers
   exposed-modules:
-      Futurice.App.Sisosota.API
-      Futurice.App.Sisosota.AWS
-      Futurice.App.Sisosota.Types
-      Futurice.App.Sisosota.Client
-  default-language: Haskell2010
+    Futurice.App.Sisosota.API
+    Futurice.App.Sisosota.AWS
+    Futurice.App.Sisosota.Client
+    Futurice.App.Sisosota.Types

--- a/smileys-app/smileys-app.cabal
+++ b/smileys-app/smileys-app.cabal
@@ -1,38 +1,38 @@
--- This file has been generated from package.yaml by hpack version 0.18.1.
---
--- see: https://github.com/sol/hpack
-
-name:           smileys-app
-version:        0
-synopsis:       Smileys backend for FutuHours
-description:    Smileys backend for FutuHours
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-rpo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-rpo/issues
-author:         Jussi Vaihia <jussi.viahia@futurice.com>
-maintainer:     Jussi Vaihia <jussi.viahia@futurice.com>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==8.0.1
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               smileys-app
+version:            0
+synopsis:           Smileys backend for FutuHours
+description:        Smileys backend for FutuHours
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-rpo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-rpo/issues
+author:             Jussi Vaihia <jussi.viahia@futurice.com>
+maintainer:         Jussi Vaihia <jussi.viahia@futurice.com>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-rpo
 
 library
-  hs-source-dirs:
-      src
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall
+  default-language:   Haskell2010
+  ghc-options:        -Wall
+  hs-source-dirs:     src
+  default-extensions:
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ScopedTypeVariables
   build-depends:
-      base                  >=4.7   && <4.13
+    , adjunctions
     , aeson
     , aeson-compat
+    , base        
     , base-compat
     , Chart
     , containers
@@ -42,14 +42,15 @@ library
     , fum-types
     , futurice-chart
     , futurice-foundation
-    , futurice-prelude
     , futurice-postgres
+    , futurice-prelude
     , futurice-servant
     , generics-sop
     , http-client
     , http-client-tls
     , http-types
     , lens
+    , linear
     , lucid
     , mtl
     , postgresql-simple
@@ -62,26 +63,21 @@ library
     , text
     , time
     , vector
-    , adjunctions
-    , linear
   exposed-modules:
-      Futurice.APL
-      Futurice.App.Smileys
-      Futurice.App.Smileys.API
-      Futurice.App.Smileys.Charts
-      Futurice.App.Smileys.Config
-      Futurice.App.Smileys.Ctx
-      Futurice.App.Smileys.Logic
-      Futurice.App.Smileys.Types
-  default-language: Haskell2010
+    Futurice.APL
+    Futurice.App.Smileys
+    Futurice.App.Smileys.API
+    Futurice.App.Smileys.Charts
+    Futurice.App.Smileys.Config
+    Futurice.App.Smileys.Ctx
+    Futurice.App.Smileys.Logic
+    Futurice.App.Smileys.Types
 
 executable smileys-app-server
-  main-is: Main.hs
-  hs-source-dirs:
-      srv
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall -threaded -rtsopts
+  default-language:   Haskell2010
+  main-is:            Main.hs
+  hs-source-dirs:     srv
+  ghc-options:        -Wall -threaded -rtsopts
   build-depends:
-      base
+    , base
     , smileys-app
-  default-language: Haskell2010

--- a/sms-proxy-client/sms-proxy-client.cabal
+++ b/sms-proxy-client/sms-proxy-client.cabal
@@ -1,33 +1,30 @@
-name:           sms-proxy-client
-version:        0
-synopsis:       SMS Proxy
-description:    Make an sms-proxy of everything
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.10.3, GHC==8.0.2
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               sms-proxy-client
+version:            0
+synopsis:           SMS Proxy
+description:        Make an sms-proxy of everything
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  ghc-options: -Wall
+  default-language: Haskell2010
+  hs-source-dirs:   src
+  ghc-options:      -Wall
   build-depends:
-      base                  >=4.7   && <4.13
     , aeson
     , aeson-compat
+    , base
     , base-compat
     , bytestring
     , futurice-prelude
@@ -38,7 +35,6 @@ library
     , servant-client
     , text
   exposed-modules:
-      Futurice.App.SmsProxy.API
-      Futurice.App.SmsProxy.Client
-      Futurice.App.SmsProxy.Types
-  default-language: Haskell2010
+    Futurice.App.SmsProxy.API
+    Futurice.App.SmsProxy.Client
+    Futurice.App.SmsProxy.Types

--- a/sms-proxy/sms-proxy.cabal
+++ b/sms-proxy/sms-proxy.cabal
@@ -1,33 +1,30 @@
-name:           sms-proxy
-version:        0
-synopsis:       SMS Proxy
-description:    Make an sms-proxy of everything
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-tested-with:    GHC==7.10.3, GHC==8.0.2
-build-type:     Simple
-cabal-version:  >= 1.10
-
-extra-source-files:
-    README.md
+cabal-version:      2.2
+name:               sms-proxy
+version:            0
+synopsis:           SMS Proxy
+description:        Make an sms-proxy of everything
+category:           Web
+homepage:           https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:        https://github.com/futurice/haskell-mega-repo/issues
+author:             Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+license:            BSD-3-Clause
+license-file:       LICENSE
+build-type:         Simple
+extra-source-files: README.md
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  ghc-options: -Wall
+  default-language: Haskell2010
+  hs-source-dirs:   src
+  ghc-options:      -Wall
   build-depends:
-      base                  >=4.7   && <4.13
     , aeson
     , aeson-compat
+    , base       
     , base-compat
     , bytestring
     , env-config
@@ -40,18 +37,16 @@ library
     , sms-proxy-client
     , text
   exposed-modules:
-      Futurice.App.SmsProxy
-      Futurice.App.SmsProxy.Config
-      Futurice.App.SmsProxy.Ctx
-      Futurice.App.SmsProxy.Logic
-  default-language: Haskell2010
+    Futurice.App.SmsProxy
+    Futurice.App.SmsProxy.Config
+    Futurice.App.SmsProxy.Ctx
+    Futurice.App.SmsProxy.Logic
 
 executable sms-proxy-server
-  main-is: Main.hs
-  hs-source-dirs:
-      srv
-  ghc-options: -Wall -threaded -rtsopts
-  build-depends:
-      base
-    , sms-proxy
   default-language: Haskell2010
+  main-is:          Main.hs
+  hs-source-dirs:   srv
+  ghc-options:      -Wall -threaded -rtsopts
+  build-depends:
+    , base
+    , sms-proxy

--- a/theme-app/theme-app.cabal
+++ b/theme-app/theme-app.cabal
@@ -1,29 +1,35 @@
-name:           theme-app
-version:        0
-synopsis:       Show Futurice colour theme
-description:    ...
-category:       Web
-homepage:       https://github.com/futurice/haskell-mega-repo#readme
-bug-reports:    https://github.com/futurice/haskell-mega-repo/issues
-author:         Oleg Grenrus <oleg.grenrus@iki.fi>
-maintainer:     Oleg Grenrus <oleg.grenrus@iki.fi>
-license:        BSD3
-license-file:   LICENSE
-build-type:     Simple
-cabal-version:  >= 1.10
+cabal-version: 2.2
+name:          theme-app
+version:       0
+synopsis:      Show Futurice colour theme
+description:   ...
+category:      Web
+homepage:      https://github.com/futurice/haskell-mega-repo#readme
+bug-reports:   https://github.com/futurice/haskell-mega-repo/issues
+author:        Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:    Oleg Grenrus <oleg.grenrus@iki.fi>
+license:       BSD-3-Clause
+license-file:  LICENSE
+build-type:    Simple
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/futurice/haskell-mega-repo
 
 library
-  hs-source-dirs:
-      src
-  default-extensions: DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable ScopedTypeVariables
-  ghc-options: -Wall
+  default-language:   Haskell2010
+  ghc-options:        -Wall
+  hs-source-dirs:     src
+  default-extensions:
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    ScopedTypeVariables
   build-depends:
-      base >= 4.7 && <4.13
-    , clay >= 0.11
+    , base
+    , clay                 >=0.11
     , env-config
     , file-embed-lzma
     , fum-types
@@ -40,31 +46,16 @@ library
     , text
     , wai-app-static
   exposed-modules:
-      Futurice.App.Theme.API
-      Futurice.App.Theme.Config
-      Futurice.App.Theme.Main
-      Futurice.App.Theme.Markup
-  default-language: Haskell2010
+    Futurice.App.Theme.API
+    Futurice.App.Theme.Config
+    Futurice.App.Theme.Main
+    Futurice.App.Theme.Markup
 
 executable theme-app-server
-  main-is: Main.hs
-  hs-source-dirs:
-      srv
-  ghc-options: -Wall -Wall -threaded -rtsopts
-  build-depends:
-      base >= 4.7 && <4.13
-    , clay >= 0.11
-    , env-config
-    , JuicyPixels
-    , futurice-foundation
-    , futurice-logo
-    , futurice-prelude
-    , futurice-servant
-    , lucid
-    , servant
-    , servant-server
-    , servant-swagger-ui
-    , text
-    , wai-app-static
-    , theme-app
   default-language: Haskell2010
+  main-is:          Main.hs
+  hs-source-dirs:   srv
+  ghc-options:      -Wall -Wall -threaded -rtsopts
+  build-depends:
+    , base
+    , theme-app


### PR DESCRIPTION
Reformatted most `.cabal` files with https://github.com/phadej/cabal-fmt, also

- removed upper bounds on `base` from internal libs, `futurice-prelude` will constraint that
- removed tested-with

this except for `servant-*` packages which might be good idea to push to Hackage at some point (and that *something* constraints stuff).