### PR TITLE
No longer send notifications of missing hours to employees with end date

### DIFF
--- a/personio-client/src/Personio/Types/SimpleEmployee.hs
+++ b/personio-client/src/Personio/Types/SimpleEmployee.hs
@@ -92,7 +92,7 @@ employeeIsActive' today e =
     && maybe True (today <=) (e ^. employeeEndDate)
 
 -- | /Note/: this considers only contract dates
-employeeIsActiveInterval :: HasSimpleEmployee e =>Interval Day -> e -> Bool
+employeeIsActiveInterval :: HasSimpleEmployee e => Interval Day -> e -> Bool
 employeeIsActiveInterval interval e =
     case (e ^. employeeHireDate, e ^. employeeEndDate) of
         (Nothing, Nothing)    -> False

--- a/personio-client/src/Personio/Types/SimpleEmployee.hs
+++ b/personio-client/src/Personio/Types/SimpleEmployee.hs
@@ -107,3 +107,9 @@ employeeIsActiveWholeInterval interval e =
         (Just hire, Nothing)  -> hire <= I.inf interval
         (Nothing, Just end)   ->                           I.sup interval <= end
         (Just hire, Just end) -> hire <= I.inf interval && I.sup interval <= end
+
+-- | Simpler check, checks only if the employee's end date is after the given interval
+employeeEndsAfterInterval :: HasSimpleEmployee e => Interval Day -> e -> Bool
+employeeEndsAfterInterval interval e = case e ^. employeeEndDate of
+    Nothing -> True
+    Just ed -> ed > I.sup interval

--- a/reports-app/src/Futurice/App/Reports/MissingHours.hs
+++ b/reports-app/src/Futurice/App/Reports/MissingHours.hs
@@ -64,14 +64,8 @@ missingHoursEmployeeNotificationPredicate :: Interval Day -> P.Employee -> Bool
 missingHoursEmployeeNotificationPredicate interval p = and
     [ p ^. P.employeeEmploymentType == Just P.Internal
     , p ^. P.employeeSalaryType == Just P.Monthly
-    , p `isAfter` sup interval
-    , P.employeeIsActiveInterval interval p
+    , P.employeeIsActiveWholeInterval interval p
     ]
-    where
-        isAfter :: P.HasSimpleEmployee e => e -> Day -> Bool
-        isAfter e d = case e ^. P.employeeEndDate of
-            Nothing -> True
-            Just ed -> ed > d
 
 
 -------------------------------------------------------------------------------

--- a/reports-app/src/Futurice/App/Reports/MissingHours.hs
+++ b/reports-app/src/Futurice/App/Reports/MissingHours.hs
@@ -64,9 +64,9 @@ missingHoursEmployeeNotificationPredicate :: Interval Day -> P.Employee -> Bool
 missingHoursEmployeeNotificationPredicate interval p = and
     [ p ^. P.employeeEmploymentType == Just P.Internal
     , p ^. P.employeeSalaryType == Just P.Monthly
-    , P.employeeIsActiveWholeInterval interval p
+    , P.employeeEndsAfterInterval interval p
+    , P.employeeIsActiveInterval interval p
     ]
-
 
 -------------------------------------------------------------------------------
 -- Data

--- a/reports-app/src/Futurice/App/Reports/MissingHours.hs
+++ b/reports-app/src/Futurice/App/Reports/MissingHours.hs
@@ -64,7 +64,7 @@ missingHoursEmployeeNotificationPredicate :: Interval Day -> P.Employee -> Bool
 missingHoursEmployeeNotificationPredicate interval p = and
     [ p ^. P.employeeEmploymentType == Just P.Internal
     , p ^. P.employeeSalaryType == Just P.Monthly
-    , p ^. P.employeeEndDate == Nothing
+    , p ^. P.employeeEndDate > Just (sup interval)
     , P.employeeIsActiveInterval interval p
     ]
 

--- a/reports-app/src/Futurice/App/Reports/MissingHours.hs
+++ b/reports-app/src/Futurice/App/Reports/MissingHours.hs
@@ -14,6 +14,7 @@ module Futurice.App.Reports.MissingHours (
     missingHoursReport,
     -- * Predicate
     missingHoursEmployeePredicate,
+    missingHoursEmployeeNotificationPredicate,
     -- * Data
     MissingHour (..),
     -- * Logic
@@ -56,6 +57,14 @@ missingHoursEmployeePredicate :: Interval Day -> P.Employee -> Bool
 missingHoursEmployeePredicate interval p = and
     [ p ^. P.employeeEmploymentType == Just P.Internal
     , p ^. P.employeeSalaryType == Just P.Monthly
+    , P.employeeIsActiveInterval interval p
+    ]
+
+missingHoursEmployeeNotificationPredicate :: Interval Day -> P.Employee -> Bool
+missingHoursEmployeeNotificationPredicate interval p = and
+    [ p ^. P.employeeEmploymentType == Just P.Internal
+    , p ^. P.employeeSalaryType == Just P.Monthly
+    , p ^. P.employeeEndDate == Nothing
     , P.employeeIsActiveInterval interval p
     ]
 

--- a/reports-app/src/Futurice/App/Reports/MissingHours.hs
+++ b/reports-app/src/Futurice/App/Reports/MissingHours.hs
@@ -64,9 +64,15 @@ missingHoursEmployeeNotificationPredicate :: Interval Day -> P.Employee -> Bool
 missingHoursEmployeeNotificationPredicate interval p = and
     [ p ^. P.employeeEmploymentType == Just P.Internal
     , p ^. P.employeeSalaryType == Just P.Monthly
-    , p ^. P.employeeEndDate > Just (sup interval)
+    , p `isAfter` sup interval
     , P.employeeIsActiveInterval interval p
     ]
+    where
+        isAfter :: P.HasSimpleEmployee e => e -> Day -> Bool
+        isAfter e d = case e ^. P.employeeEndDate of
+            Nothing -> True
+            Just ed -> ed > d
+
 
 -------------------------------------------------------------------------------
 -- Data

--- a/reports-app/src/Futurice/App/Reports/MissingHoursNotifications.hs
+++ b/reports-app/src/Futurice/App/Reports/MissingHoursNotifications.hs
@@ -28,7 +28,7 @@ import Futurice.App.Preferences.Types
 import Futurice.App.Reports.Config
 import Futurice.App.Reports.Ctx
 import Futurice.App.Reports.MissingHours
-       (missingHourDay, missingHoursEmployeePredicate, missingHoursReport)
+       (missingHourDay, missingHoursEmployeeNotificationPredicate, missingHoursReport)
 import Futurice.App.Reports.Templates
 
 -- | Pick the latter from
@@ -65,7 +65,7 @@ missingHoursNotifications ctx = runLogT "missing-hours-notifications" lgr $ do
 
         (ppm, Report _ report) <- liftIO $ runIntegrations' ctx $ (,)
             <$> personioPlanmillMap
-            <*> missingHoursReport missingHoursEmployeePredicate interval
+            <*> missingHoursReport missingHoursEmployeeNotificationPredicate interval
 
         let logins = HM.keys report
         prefs <- liftIO $ getPreferences mgr preferencesBurl logins


### PR DESCRIPTION
This should prevent the notification runner from sending messages to ex employees. 

This basically adds a check only on the notifications runner to not send notifications to someone with a set end date.