### PR TITLE
Add Month column to missing hours table

### DIFF
--- a/futurice-reports/src/Futurice/Report/Columns.hs
+++ b/futurice-reports/src/Futurice/Report/Columns.hs
@@ -484,6 +484,7 @@ data ColumnType
     | CTNumber   -- ^ number
     | CTBool     -- ^ boolean
     | CTDay      -- ^ day: @2016-10-25@
+    | CTMonth    -- ^ month: @2016-10@
     | CTDayDiff  -- ^ day difference: @5 days"
     | CTHourDiff -- ^ hour difference: @5 hours"
     | CTFumUser  -- ^ FUM user (e.g. abcd)
@@ -494,6 +495,7 @@ instance ToJSON ColumnType where
     toJSON CTNumber   = "number"
     toJSON CTBool     = "bool"
     toJSON CTDay      = "day"
+    toJSON CTMonth    = "month"
     toJSON CTDayDiff  = "dayDiff"
     toJSON CTHourDiff = "hourDiff"
     toJSON CTFumUser  = "fumUser"
@@ -522,6 +524,8 @@ columnTypeAggregate CTNumber =
 columnTypeAggregate CTBool =
     [ AggFirst, AggCount, AggCollectDistinct ]
 columnTypeAggregate CTDay =
+    [ AggFirst, AggCount, AggCountDistinct, AggCollect, AggCollectDistinct ]
+columnTypeAggregate CTMonth =
     [ AggFirst, AggCount, AggCountDistinct, AggCollect, AggCollectDistinct ]
 columnTypeAggregate CTDayDiff =
     [ minBound .. maxBound ]
@@ -586,6 +590,10 @@ instance ReportValue Word64 where
 
 instance ReportValue Day where
     reportValueType _ = CTDay
+    reportValueHtml = fromString . show
+
+instance ReportValue Month where
+    reportValueType _ = CTMonth
     reportValueHtml = fromString . show
 
 instance ReportValue UTCTime where

--- a/reports-app/src/Futurice/App/Reports/MissingHours.hs
+++ b/reports-app/src/Futurice/App/Reports/MissingHours.hs
@@ -36,7 +36,8 @@ import Futurice.Integrations
 import Futurice.Lucid.Foundation
 import Futurice.Prelude
 import Futurice.Report.Columns
-import Futurice.Time
+import Futurice.Time             
+import Futurice.Time.Month       (dayToMonth)
 import Numeric.Interval.NonEmpty (Interval, inf, sup)
 import Prelude ()
 
@@ -86,8 +87,13 @@ deriveVia [t| FromJSON MissingHour `Via` Sopica MissingHour |]
 instance ToSchema MissingHour where declareNamedSchema = sopDeclareNamedSchema
 
 instance ToColumns MissingHour where
-    type Columns MissingHour = '[Day, NDT 'Hours Centi]
-    toColumns (MissingHour d c) = [I d :* I c :* Nil]
+    type Columns MissingHour = '[Day, Month, NDT 'Hours Centi]
+    toColumns (MissingHour d c) = [I d :* I (dayToMonth d) :* I c :* Nil]
+    columnNames _ =
+        K "day" :*
+        K "month" :*
+        K "capacity" :*
+        Nil
 
 -------------------------------------------------------------------------------
 -- Report


### PR DESCRIPTION
Creates the necessary type instances to display also a month column in the missing hours table.