### PR TITLE
Gather paged value-creation data for a full report

### DIFF
--- a/planmill-client/cli/Caching.hs
+++ b/planmill-client/cli/Caching.hs
@@ -75,7 +75,7 @@ instance MonadPlanMillC m User                 => CachingTC m User
 instance MonadPlanMillC m UserCapacity         => CachingTC m UserCapacity
 instance MonadPlanMillC m (EnumDesc s)         => CachingTC m (EnumDesc s)
 instance MonadPlanMillC m AllRevenues2         => CachingTC m AllRevenues2
-instance MonadPlanMillC m ValueCreationByMonth => CachingTC m ValueCreationByMonth
+instance MonadPlanMillC m PersonValueCreation  => CachingTC m PersonValueCreation
 
 instance (MonadPlanMillC m (Vector a), CachingTC m a) => CachingTC m (Vector a)
 

--- a/planmill-client/src/Control/Monad/PlanMill.hs
+++ b/planmill-client/src/Control/Monad/PlanMill.hs
@@ -68,7 +68,6 @@ class
     , MonadPlanMillC m UserCapacity
     , ForallFSymbol (MonadPlanMillC m) EnumDesc
     , MonadPlanMillC m AllRevenues2
-    , MonadPlanMillC m ValueCreationByMonth
     , MonadPlanMillC m PersonValueCreation
     )
   => MonadPlanMillConstraint m where

--- a/planmill-client/src/Control/Monad/PlanMill.hs
+++ b/planmill-client/src/Control/Monad/PlanMill.hs
@@ -69,6 +69,7 @@ class
     , ForallFSymbol (MonadPlanMillC m) EnumDesc
     , MonadPlanMillC m AllRevenues2
     , MonadPlanMillC m ValueCreationByMonth
+    , MonadPlanMillC m PersonValueCreation
     )
   => MonadPlanMillConstraint m where
 

--- a/planmill-client/src/PlanMill/Endpoints.hs
+++ b/planmill-client/src/PlanMill/Endpoints.hs
@@ -358,7 +358,7 @@ allRevenuesReport = planMillGet $ t "reports" // t "All Revenues 2"
 --
 -- See <https://developers.planmill.com/api/#reports__reportName__get>
 valueCreationByMonthReport :: Int -> PlanMill ValueCreationByMonth
-valueCreationByMonthReport year = planMillGetQs (Map.fromList [("param1", textShow year)]) $ t "reports" // t "Value creation per month by employee"
+valueCreationByMonthReport year = planMillPagedGetQs (Map.fromList [("param1", textShow year)]) $ t "reports" // t "Value creation per month by employee"
 
 -- | Get a list of project's members
 --

--- a/planmill-client/src/PlanMill/Endpoints.hs
+++ b/planmill-client/src/PlanMill/Endpoints.hs
@@ -357,7 +357,7 @@ allRevenuesReport = planMillGet $ t "reports" // t "All Revenues 2"
 -- | Get the "Value creation per month by employee" report
 --
 -- See <https://developers.planmill.com/api/#reports__reportName__get>
-valueCreationByMonthReport :: Int -> PlanMill ValueCreationByMonth
+valueCreationByMonthReport :: Int -> PlanMill PersonValueCreations
 valueCreationByMonthReport year = planMillPagedGetQs (Map.fromList [("param1", textShow year)]) $ t "reports" // t "Value creation per month by employee"
 
 -- | Get a list of project's members

--- a/planmill-client/src/PlanMill/Queries.hs
+++ b/planmill-client/src/PlanMill/Queries.hs
@@ -345,8 +345,8 @@ allRevenuesReport year month = planmillQuery
 --
 -- See <https://developers.planmill.com/api/#reports__reportName__get>
 valueCreationByMonthReport :: (MonadPlanMillQuery m) => Integer -> m ValueCreationByMonth
-valueCreationByMonthReport year = planmillQuery
-    $ QueryGet QueryTagValueCreation (Map.fromList [("param1",textShow year)])
+valueCreationByMonthReport year = planmillVectorQuery
+    $ QueryPagedGet QueryTagValueCreation (Map.fromList [("param1",textShow year)])
     $ toUrlParts ("reports" :: Text) // ("Value creation per month by employee" :: Text)
 
 -- | Get a list of tasks.

--- a/planmill-client/src/PlanMill/Queries.hs
+++ b/planmill-client/src/PlanMill/Queries.hs
@@ -58,7 +58,7 @@ import PlanMill.Types
        CapacityCalendars, Me, Project (..), ProjectId, ProjectMembers,
        Projects, SimpleProject, Task, TaskId, Tasks, Team, TeamId, TimeBalance,
        Timereport, Timereports, User, UserCapacities, UserId, Users,
-       ValueCreationByMonth, ViewTemplate (..), identifier, sProject,
+       PersonValueCreations, ViewTemplate (..), identifier, sProject,
        viewTemplateToInt)
 import PlanMill.Types.Enumeration
 import PlanMill.Types.Meta        (Meta, lookupFieldEnum)
@@ -344,7 +344,7 @@ allRevenuesReport year month = planmillQuery
 -- | Get Value creation by month per employee Report
 --
 -- See <https://developers.planmill.com/api/#reports__reportName__get>
-valueCreationByMonthReport :: (MonadPlanMillQuery m) => Integer -> m ValueCreationByMonth
+valueCreationByMonthReport :: (MonadPlanMillQuery m) => Integer -> m PersonValueCreations
 valueCreationByMonthReport year = planmillVectorQuery
     $ QueryPagedGet QueryTagValueCreation (Map.fromList [("param1",textShow year)])
     $ toUrlParts ("reports" :: Text) // ("Value creation per month by employee" :: Text)

--- a/planmill-client/src/PlanMill/Types/Query.hs
+++ b/planmill-client/src/PlanMill/Types/Query.hs
@@ -57,7 +57,7 @@ import PlanMill.Types.Me               (Me)
 import PlanMill.Types.Meta             (Meta)
 import PlanMill.Types.Project
        (Project, ProjectMember, ProjectMembers, Projects)
-import PlanMill.Types.Report           (AllRevenues2, ValueCreationByMonth, PersonValueCreation)
+import PlanMill.Types.Report           (AllRevenues2, PersonValueCreations, PersonValueCreation)
 import PlanMill.Types.Request
        (PlanMill (..), QueryString, planMillGetQs, planMillPagedGetQs)
 import PlanMill.Types.ResultInterval
@@ -466,7 +466,7 @@ type QueryTypes = '[ Timereports, UserCapacities
     , Account, Accounts
     , Assignment, Assignments
     , CapacityCalendar, CapacityCalendars
-    , AllRevenues2, ValueCreationByMonth, PersonValueCreation
+    , AllRevenues2, PersonValueCreations, PersonValueCreation
     ]
 
 -- | A bit fancier than ':~:'

--- a/planmill-client/src/PlanMill/Types/Query.hs
+++ b/planmill-client/src/PlanMill/Types/Query.hs
@@ -267,7 +267,7 @@ instance SBoolI (f == I) => Binary (SomeQueryTag f) where
         (12, Just Refl) -> pure $ SomeQueryTag QueryTagAllRevenue
         (13, _)         -> pure $ SomeQueryTag QueryTagProjectMember
         (14, _)         -> pure $ SomeQueryTag QueryTagAssignment
-        (15, _) -> pure $ SomeQueryTag QueryTagValueCreation
+        (15, _)         -> pure $ SomeQueryTag QueryTagValueCreation
 
         _ -> fail $ "Invalid tag " ++ show n
 

--- a/planmill-client/src/PlanMill/Types/Query.hs
+++ b/planmill-client/src/PlanMill/Types/Query.hs
@@ -57,7 +57,7 @@ import PlanMill.Types.Me               (Me)
 import PlanMill.Types.Meta             (Meta)
 import PlanMill.Types.Project
        (Project, ProjectMember, ProjectMembers, Projects)
-import PlanMill.Types.Report           (AllRevenues2, ValueCreationByMonth)
+import PlanMill.Types.Report           (AllRevenues2, ValueCreationByMonth, PersonValueCreation)
 import PlanMill.Types.Request
        (PlanMill (..), QueryString, planMillGetQs, planMillPagedGetQs)
 import PlanMill.Types.ResultInterval
@@ -91,7 +91,7 @@ data QueryTag f a where
     QueryTagEnumDesc       :: KnownSymbol enum => !(Proxy enum) -> QueryTag I (EnumDesc enum)
     QueryTagAllRevenue     :: QueryTag I AllRevenues2
     QueryTagAssignment     :: QueryTag f Assignment
-    QueryTagValueCreation  :: QueryTag I ValueCreationByMonth
+    QueryTagValueCreation  :: QueryTag f PersonValueCreation
 
 -- | Planmill query (i.e. read-only operation).
 --
@@ -267,7 +267,7 @@ instance SBoolI (f == I) => Binary (SomeQueryTag f) where
         (12, Just Refl) -> pure $ SomeQueryTag QueryTagAllRevenue
         (13, _)         -> pure $ SomeQueryTag QueryTagProjectMember
         (14, _)         -> pure $ SomeQueryTag QueryTagAssignment
-        (15, Just Refl) -> pure $ SomeQueryTag QueryTagValueCreation
+        (15, _) -> pure $ SomeQueryTag QueryTagValueCreation
 
         _ -> fail $ "Invalid tag " ++ show n
 
@@ -308,7 +308,7 @@ instance SBoolI (f == I) => FromJSON (SomeQueryTag f) where
         ("allrevenue", Just Refl)    -> pure $ SomeQueryTag QueryTagAllRevenue
         ("projectmember", _)         -> pure $ SomeQueryTag QueryTagProjectMember
         ("assignment", _)            -> pure $ SomeQueryTag QueryTagAssignment
-        ("valuecreation", Just Refl) -> pure $ SomeQueryTag QueryTagValueCreation
+        ("valuecreation", _)         -> pure $ SomeQueryTag QueryTagValueCreation
         (_, Just Refl) | T.isPrefixOf pfx t
             -> pure $ reifySymbol (T.drop (T.length pfx) t ^. unpacked) mk
           where
@@ -466,7 +466,7 @@ type QueryTypes = '[ Timereports, UserCapacities
     , Account, Accounts
     , Assignment, Assignments
     , CapacityCalendar, CapacityCalendars
-    , AllRevenues2, ValueCreationByMonth
+    , AllRevenues2, ValueCreationByMonth, PersonValueCreation
     ]
 
 -- | A bit fancier than ':~:'
@@ -505,6 +505,7 @@ queryTagVectorType QueryTagAbsence       = insertNS Refl
 queryTagVectorType QueryTagAccount       = insertNS Refl
 queryTagVectorType QueryTagCalendar      = insertNS Refl
 queryTagVectorType QueryTagAssignment    = insertNS Refl
+queryTagVectorType QueryTagValueCreation = insertNS Refl
 
 -- | Reflect the type of 'Query'.
 queryType

--- a/planmill-client/src/PlanMill/Types/Report.hs
+++ b/planmill-client/src/PlanMill/Types/Report.hs
@@ -6,7 +6,7 @@ module PlanMill.Types.Report (
     Report,
     Reports,
     ReportsCategories,
-    ValueCreationByMonth,
+    PersonValueCreations,
     PersonValueCreation (..),
     getRevenuesData) where
 
@@ -145,7 +145,7 @@ data PersonValueCreation = PersonValueCreation
     , _pvcNovemberValue  :: !Double
     , _pvcDecemberValue  :: !Double
     }  deriving (Eq, Show, Binary, GhcGeneric, SopGeneric, ToSchema, ToJSON, NFData, HasSemanticVersion, HasDatatypeInfo)
-type ValueCreationByMonth = Vector PersonValueCreation
+type PersonValueCreations = Vector PersonValueCreation
 
 instance AnsiPretty PersonValueCreation
 instance HasStructuralInfo PersonValueCreation where structuralInfo = sopStructuralInfo

--- a/planmill-client/src/PlanMill/Types/Report.hs
+++ b/planmill-client/src/PlanMill/Types/Report.hs
@@ -8,8 +8,7 @@ module PlanMill.Types.Report (
     ReportsCategories,
     ValueCreationByMonth,
     PersonValueCreation (..),
-    getRevenuesData)
-    where
+    getRevenuesData) where
 
 import Data.Aeson
 import Data.Aeson.Types  (Parser)

--- a/planmill-client/src/PlanMill/Types/Report.hs
+++ b/planmill-client/src/PlanMill/Types/Report.hs
@@ -8,8 +8,8 @@ module PlanMill.Types.Report (
     ReportsCategories,
     ValueCreationByMonth,
     PersonValueCreation (..),
-    getRevenuesData,
-    getValueCreationData) where
+    getRevenuesData)
+    where
 
 import Data.Aeson
 import Data.Aeson.Types  (Parser)
@@ -130,14 +130,6 @@ instance FromJSON AllRevenuesPortfolio where
           Just a -> pure a
           Nothing -> mempty
 
-newtype ValueCreationByMonth = ValueCreationByMonth { getValueCreationData :: Vector PersonValueCreation }
-    deriving (Eq, Show, Generic)
-    deriving anyclass (Binary, ToSchema, NFData, HasSemanticVersion)
-    deriving newtype (ToJSON, FromJSON)
-
-instance AnsiPretty ValueCreationByMonth
-instance HasStructuralInfo ValueCreationByMonth
-
 data PersonValueCreation = PersonValueCreation
     { _pvcTeam           :: !Text
     , _pvcPerson         :: !Text
@@ -154,6 +146,7 @@ data PersonValueCreation = PersonValueCreation
     , _pvcNovemberValue  :: !Double
     , _pvcDecemberValue  :: !Double
     }  deriving (Eq, Show, Binary, GhcGeneric, SopGeneric, ToSchema, ToJSON, NFData, HasSemanticVersion, HasDatatypeInfo)
+type ValueCreationByMonth = Vector PersonValueCreation
 
 instance AnsiPretty PersonValueCreation
 instance HasStructuralInfo PersonValueCreation where structuralInfo = sopStructuralInfo

--- a/proxy-app/tests/Tests.hs
+++ b/proxy-app/tests/Tests.hs
@@ -41,9 +41,9 @@ binaryTagTests = testGroup "BinaryTagged tags" $ map mk tags
     tags :: [BTTest]
     tags =
         [ BTTest "PlanMill.SomeResponse" (Proxy :: Proxy PM.SomeResponse)
-            0 "84b5f5b2ee96b46fe509eb4bfdc195b25de552bb"
+            0 "ea8fea1c228229d147ddb80132aabc55adec8aa2"
         , BTTest "planmill-haxl endpoint" (Proxy :: Proxy [Either Text PM.SomeResponse])
-            0 "fe592b7b53d68624b33368faf9a458d15c839118"
+            0 "dce39c3ef79831b7a0c88003c7933154860472d9"
         , BTTest "PlanMill.Projects" (Proxy :: Proxy PM.Projects)
             0 "943eec14806b8d90fa7d3e4566f4aca06e8c1b2d"
         , BTTest "PlanMill.Tasks" (Proxy :: Proxy PM.Tasks)

--- a/reports-app/src/Futurice/App/Reports/ValueCreation.hs
+++ b/reports-app/src/Futurice/App/Reports/ValueCreation.hs
@@ -57,7 +57,7 @@ valueCreationReport myear = do
     year <- maybe (monthYear <$> currentMonth) pure myear
     report <- PMQ.valueCreationByMonthReport year
     nameMap <- planmillNameToPersonioIdMap
-    pure $ ValueCreationReport year $ fmap (\x -> toRow nameMap x) $ toList $ PM.getValueCreationData report
+    pure $ ValueCreationReport year $ fmap (\x -> toRow nameMap x) $ toList report
   where
     nameSplit v = case (T.splitOn ", " $ PM._pvcPerson v) of
                     (l:f:_) -> Just (f,l)


### PR DESCRIPTION
Prior the report was limited to default 1000 entries.